### PR TITLE
Remotes in description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: r
 cache: packages
 sudo: false
 
+before_install:
+ - Rscript -e 'install.packages("pkgdown")'
+
 r_github_packages:
   - jimhester/covr
 
@@ -50,7 +53,6 @@ addons:
     - r-cran-speaq
     - r-cran-stringr
     - r-cran-tsp
-    - r-cran-pkgdown
     - r-cran-rmarkdown
     - r-cran-sparsem
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: r
 cache: packages
 sudo: false
 
-before_install:
- - Rscript -e 'install.packages("remotes")'
- - Rscript -e 'remotes::install_github("danielcanueto/rDolphin")'
- - Rscript -e 'remotes::install_git("https://gitlab.com/CarlBrunius/MUVR.git")'
- - Rscript -e 'remotes::install_cran("pkgdown")'
-
 r_github_packages:
   - jimhester/covr
 
@@ -56,4 +50,8 @@ addons:
     - r-cran-speaq
     - r-cran-stringr
     - r-cran-tsp
+    - r-cran-pkgdown
+    - r-cran-rmarkdown
+    - r-cran-sparsem
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,5 +55,6 @@ addons:
     - r-cran-tsp
     - r-cran-rmarkdown
     - r-cran-sparsem
-
-
+    - r-cran-rgl
+    - r-cran-nloptr
+ 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,6 +85,10 @@ Suggests:
     ASICS,
     NIHSrods,
     knitr
+biocViews:
+Remotes:
+  gitlab::CarlBrunius/MUVR,
+  github::danielcanueto/rDolphin
 RoxygenNote: 6.1.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -11,12 +11,10 @@ outlier detection among others. See the package vignette for details.
 
 ## Installation
 
-AlpsNMR installation requires at least R 3.5, and some packages not yet published on CRAN or BioConductor:
+AlpsNMR can be installed with the `remotes` package. Note that it uses packages from
+CRAN, from BioConductor and from git repositories:
 
-    install.packages(c("BiocManager", "remotes"))
-    BiocManager::install(c("impute", "MassSpecWavelet", "mixOmics"))
-    remotes::install_git("https://gitlab.com/CarlBrunius/MUVR.git")
-    remotes::install_github("danielcanueto/rDolphin")
+    install.packages("remotes")
     remotes::install_github("sipss/AlpsNMR")
 
 Quick start


### PR DESCRIPTION
This PR simplifies the installation of the package by setting `biocViews:`in the DESCRIPTION file so BioConductor dependent packages are automatically installed. It also adds the `Remotes:` field use by the `remotes` package.

With respect to Travis, some dependencies are installed through apt to make the builds faster.