### PR TITLE
Fix order of chemshift_range limits in plot

### DIFF
--- a/R/nmr_detect_peaks_align.R
+++ b/R/nmr_detect_peaks_align.R
@@ -205,6 +205,7 @@ nmr_detect_peaks_plot <- function(nmr_dataset, peak_data, NMRExperiment, ...) {
   dots <- list(...)
   if ("chemshift_range" %in% names(dots)) {
     chemshift_range <- dots[["chemshift_range"]]
+    chemshift_range[1:2] <- range(chemshift_range[1:2])
   } else {
     chemshift_range <- range(peak_data$ppm)
   }

--- a/R/plots.R
+++ b/R/plots.R
@@ -21,6 +21,12 @@ plot.nmr_dataset_1D <- function(x, NMRExperiment = NULL,
                                 ...) {
   if (is.null(chemshift_range)) {
     chemshift_range <- range(x$axis)
+  } else if (length(chemshift_range) == 2) {
+    chemshift_range <- range(chemshift_range)
+  } else if (length(chemshift_range) == 3) {
+    chemshift_range <- c(range(chemshift_range[1:2]), chemshift_range[3])
+  } else {
+    stop("chemshift_range should be a numeric vector of length 2 or 3.")
   }
   
   if (is.null(NMRExperiment)) {


### PR DESCRIPTION
Plotting functions can now specify the order of the elements of chemshift_range like (min, max), (max, min), (min, max, step), (max, min, step)