### PR TITLE
Fix: refactor tests

### DIFF
--- a/R/import_jdx.R
+++ b/R/import_jdx.R
@@ -4,13 +4,6 @@
 # Author: Sergio Oller
 
 
-# If this package depends on R>=3.3.0 then this function is already
-# in base R and can be removed
-startsWith <- function(x, prefix) {
-  return(substring(x, 1, nchar(prefix)) == prefix)
-}
-
-
 #' Remove comments from JDX files
 #'
 #' JDX comments start with \code{$$}.

--- a/tests/testthat/test-peak_detection.R
+++ b/tests/testthat/test-peak_detection.R
@@ -5,9 +5,7 @@ test_that("nmr_detect_peaks & nmr_align_find_ref & nmr_align & nmr_integrate_pea
   dataset <- nmr_read_samples_dir(dir_to_demo_dataset)
   data2 <- dataset[1:3]
   dataset <- nmr_interpolate_1D(dataset, axis = c(min = 1, max = 2, by = 0.002))
-  Ch = to_ChemoSpec(dataset)
-  
-  
+
   peak_table <- nmr_detect_peaks(dataset,
                                  nDivRange_ppm = 0.1,
                                  scales = seq(1, 16, 2),
@@ -19,9 +17,8 @@ test_that("nmr_detect_peaks & nmr_align_find_ref & nmr_align & nmr_integrate_pea
                        maxShift_ppm = 0.0015, 
                        acceptLostPeak = FALSE)
 
-  plot = nmr_detect_peaks_plot (dataset,peak_table,NMRExp_ref)
+  plot <- nmr_detect_peaks_plot(dataset,peak_table,NMRExp_ref)
   
-  expect_true(is.list(Ch))
   
   peak_table_integration = nmr_integrate_peak_positions(
   samples = dataset,

--- a/tests/testthat/test-to_ASICS.R
+++ b/tests/testthat/test-to_ASICS.R
@@ -7,10 +7,3 @@ dataset <- new_nmr_dataset_1D(ppm_axis = c(0:10),
 asics = to_ASICS(dataset)
 expect_true(is.integer((asics@spectra@Dim)))
 })
-
-test_that("startsWith",{
-startsWith <- function(x, prefix) {
-  return(substring(x, 1, nchar(prefix)) == prefix)
-}
-expect_true(startsWith(22,22))
-})

--- a/tests/testthat/test-to_ASICS.R
+++ b/tests/testthat/test-to_ASICS.R
@@ -1,9 +1,10 @@
 context("test-to_ASICS")
 
 test_that("to_ASICS", {
-dataset <- new_nmr_dataset_1D(ppm_axis = c(0:10),
-                              data_1r = matrix(sample(0:43,replace = FALSE), nrow = 4),
-                              metadata = list(external = data.frame(NMRExperiment = c("10", "20", "30","40"))))
-asics = to_ASICS(dataset)
-expect_true(is.integer((asics@spectra@Dim)))
+  skip_if_not_installed("ASICS")
+  dataset <- new_nmr_dataset_1D(ppm_axis = c(0:10),
+                                data_1r = matrix(sample(0:43,replace = FALSE), nrow = 4),
+                                metadata = list(external = data.frame(NMRExperiment = c("10", "20", "30","40"))))
+  asics = to_ASICS(dataset)
+  expect_true(is.integer((asics@spectra@Dim)))
 })

--- a/tests/testthat/test-to_ChemoSpec.R
+++ b/tests/testthat/test-to_ChemoSpec.R
@@ -1,0 +1,11 @@
+context("test-to_ChemoSpec")
+
+test_that("to_ChemoSpec works", {
+  skip_if_not_installed("ChemoSpec")
+  dir_to_demo_dataset <- system.file("dataset-demo", package = "AlpsNMR")
+  dataset <- nmr_read_samples_dir(dir_to_demo_dataset)
+  data2 <- dataset[1:3]
+  dataset <- nmr_interpolate_1D(dataset, axis = c(min = 1, max = 2, by = 0.002))
+  Ch <- to_ChemoSpec(dataset)
+  expect_true(is.list(Ch))
+})


### PR DESCRIPTION
Minor fixes here and there:

- Since we depend on R-3.5, the startsWith function is now available in base R and we don't need to include it in our package.
- The tests that export to ASICS and ChemoSpec are skipped automatically if the respective packages are not installed. Both ASICS and ChemoSpec are *Suggested* packages in the DESCRIPTION file, so it is not mandatory to install them to install AlpsNMR.