### PR TITLE
Minor fixes to nmr_identify_regions_*

### DIFF
--- a/R/nmr_identify_regions.R
+++ b/R/nmr_identify_regions.R
@@ -18,20 +18,22 @@
 #' @family peak integration functions
 #' @param ppm_to_assign A vector with the ppm regions to assign
 #' @param num_proposed_compounds set the number of proposed metabolites sorted by the number times reported in the HMDB: `HMDB_blood`.
-nmr_identify_regions_blood <- function(ppm_to_assign, num_proposed_compounds = 3){
+#' @param verbose Logical value. Set it to TRUE to print additional information
+nmr_identify_regions_blood <- function(ppm_to_assign, num_proposed_compounds = 3, verbose = FALSE){
   HMDB_blood <- NULL
   utils::data("HMDB_blood", package = "AlpsNMR", envir = environment())
   output_assignation_list=HMDB_blood[NULL,]
   
   for(ppm in ppm_to_assign){
-    print(ppm)
     lower_ppm_right_edge <- ppm - 0.015
     higher_ppm_left_edge <- ppm + 0.015
     
     ind= intersect(which(HMDB_blood$Shift_ppm<higher_ppm_left_edge),which(HMDB_blood$Shift_ppm>lower_ppm_right_edge))
     assignation_list <- as.data.frame(HMDB_blood[ind,])
-    message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1], " or ", assignation_list[3,1])
-    message("")
+    if (isTRUE(verbose)) {
+      message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1], " or ", assignation_list[3,1])
+      message("")
+    }
     output_assignation_list <-rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
   }
   output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each=num_proposed_compounds)
@@ -71,20 +73,22 @@ NULL
 #' @family peak integration functions
 #' @param ppm_to_assign A vector with the ppm regions to assign
 #' @param num_proposed_compounds set the number of proposed metabolites sorted by the number times reported in the HMDB: `HMDB_urine`.
-nmr_identify_regions_urine <- function(ppm_to_assign, num_proposed_compounds = 5){
+#' @param verbose Logical value. Set it to TRUE to print additional information
+nmr_identify_regions_urine <- function(ppm_to_assign, num_proposed_compounds = 5, verbose = FALSE){
   HMDB_urine <- NULL
   utils::data("HMDB_urine", package = "AlpsNMR", envir = environment())
   output_assignation_list=HMDB_urine[NULL,]
   
   for(ppm in ppm_to_assign){
-    print(ppm)
     lower_ppm_right_edge <- ppm - 0.015
     higher_ppm_left_edge <- ppm + 0.015
     
     ind= intersect(which(HMDB_urine$Shift_ppm<higher_ppm_left_edge),which(HMDB_urine$Shift_ppm>lower_ppm_right_edge))
     assignation_list <- as.data.frame(HMDB_urine[ind,])
-    message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1],", ", assignation_list[3,1],", ", assignation_list[4,1]," or ", assignation_list[5,1])
-    message("")
+    if (isTRUE(verbose)) {
+      message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1],", ", assignation_list[3,1],", ", assignation_list[4,1]," or ", assignation_list[5,1])
+      message("")
+    }
     output_assignation_list <-rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
   }
   output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each=num_proposed_compounds)

--- a/R/nmr_identify_regions.R
+++ b/R/nmr_identify_regions.R
@@ -22,21 +22,22 @@
 nmr_identify_regions_blood <- function(ppm_to_assign, num_proposed_compounds = 3, verbose = FALSE){
   HMDB_blood <- NULL
   utils::data("HMDB_blood", package = "AlpsNMR", envir = environment())
-  output_assignation_list=HMDB_blood[NULL,]
+  output_assignation_list <- HMDB_blood[NULL,]
   
-  for(ppm in ppm_to_assign){
+  for (ppm in ppm_to_assign) {
     lower_ppm_right_edge <- ppm - 0.015
     higher_ppm_left_edge <- ppm + 0.015
     
-    ind= intersect(which(HMDB_blood$Shift_ppm<higher_ppm_left_edge),which(HMDB_blood$Shift_ppm>lower_ppm_right_edge))
+    ind <- intersect(which(HMDB_blood$Shift_ppm < higher_ppm_left_edge),
+                     which(HMDB_blood$Shift_ppm > lower_ppm_right_edge))
     assignation_list <- as.data.frame(HMDB_blood[ind,])
     if (isTRUE(verbose)) {
       message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1], " or ", assignation_list[3,1])
       message("")
     }
-    output_assignation_list <-rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
+    output_assignation_list <- rbind(output_assignation_list, assignation_list[1:num_proposed_compounds,])
   }
-  output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each=num_proposed_compounds)
+  output_assignation_list$ppm_to_assign <- rep(ppm_to_assign, each = num_proposed_compounds)
   
   # counts=output_assignation_list %>% dplyr::count(Metabolite) %>% dplyr::arrange(dplyr::desc(n))
   # colnames(counts) <- c("Metabolite", "Counts")
@@ -44,7 +45,8 @@ nmr_identify_regions_blood <- function(ppm_to_assign, num_proposed_compounds = 3
   output_assignation_list <- output_assignation_list[order(output_assignation_list$ppm_to_assign,-output_assignation_list$Blood_concentration, -output_assignation_list$n_reported_in_Blood),]
   return(output_assignation_list)
 }
-NULL
+
+
 #' The Human Metabolome DataBase multiplet table: blood metabolites normally found in NMR-based metabolomics
 #'
 #' @name HMDB_blood
@@ -52,6 +54,7 @@ NULL
 #' @references \url{hmdb.ca}
 #' @keywords data
 NULL
+
 #' NMR peak identification (urine samples)
 #' 
 #' Identify given regions and return a data frame with plausible assignations 
@@ -77,21 +80,22 @@ NULL
 nmr_identify_regions_urine <- function(ppm_to_assign, num_proposed_compounds = 5, verbose = FALSE){
   HMDB_urine <- NULL
   utils::data("HMDB_urine", package = "AlpsNMR", envir = environment())
-  output_assignation_list=HMDB_urine[NULL,]
+  output_assignation_list <- HMDB_urine[NULL,]
   
-  for(ppm in ppm_to_assign){
+  for (ppm in ppm_to_assign) {
     lower_ppm_right_edge <- ppm - 0.015
     higher_ppm_left_edge <- ppm + 0.015
     
-    ind= intersect(which(HMDB_urine$Shift_ppm<higher_ppm_left_edge),which(HMDB_urine$Shift_ppm>lower_ppm_right_edge))
+    ind <- intersect(which(HMDB_urine$Shift_ppm < higher_ppm_left_edge),
+                     which(HMDB_urine$Shift_ppm > lower_ppm_right_edge))
     assignation_list <- as.data.frame(HMDB_urine[ind,])
     if (isTRUE(verbose)) {
       message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1],", ", assignation_list[3,1],", ", assignation_list[4,1]," or ", assignation_list[5,1])
       message("")
     }
-    output_assignation_list <-rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
+    output_assignation_list <- rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
   }
-  output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each=num_proposed_compounds)
+  output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each = num_proposed_compounds)
   
   #counts=output_assignation_list %>% dplyr::count(Metabolite) %>% dplyr::arrange(dplyr::desc(n))
   #colnames(counts) <- c("Metabolite", "Counts")
@@ -99,7 +103,7 @@ nmr_identify_regions_urine <- function(ppm_to_assign, num_proposed_compounds = 5
   output_assignation_list <- output_assignation_list[order(output_assignation_list$ppm_to_assign,-output_assignation_list$Urine_concentration, -output_assignation_list$n_reported_in_Urine),]
   return(output_assignation_list)
 }
-NULL
+
 #' The Human Metabolome DataBase multiplet table: urine metabolites normally found in NMR-based metabolomics
 #'
 #' @name HMDB_urine
@@ -126,30 +130,30 @@ NULL
 #' @family peak integration functions
 #' @param ppm_to_assign A vector with the ppm regions to assign
 #' @param num_proposed_compounds set the number of proposed metabolites in `HMDB_cell`.
-nmr_identify_regions_cell <- function(vector, ...) {
-  UseMethod("nmr_identify_regions_cell")
-}
-nmr_identify_regions_cell <- function(ppm_to_assign, num_proposed_compounds = 3){
+#' @param verbose Logical value. Set it to TRUE to print additional information
+nmr_identify_regions_cell <- function(ppm_to_assign, num_proposed_compounds = 3, verbose = FALSE){
   HMDB_cell <- NULL
   utils::data("HMDB_cell", package = "AlpsNMR", envir = environment())
-  output_assignation_list=HMDB_cell[NULL,]
+  output_assignation_list <- HMDB_cell[NULL,]
   
-  for(ppm in ppm_to_assign){
-    print(ppm)
+  for (ppm in ppm_to_assign) {
     lower_ppm_right_edge <- ppm - 0.015
     higher_ppm_left_edge <- ppm + 0.015
     
-    ind= intersect(which(HMDB_cell$Shift_ppm<higher_ppm_left_edge),which(HMDB_cell$Shift_ppm>lower_ppm_right_edge))
+    ind <- intersect(which(HMDB_cell$Shift_ppm < higher_ppm_left_edge),
+                     which(HMDB_cell$Shift_ppm > lower_ppm_right_edge))
     assignation_list <- as.data.frame(HMDB_cell[ind,])
-    message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1],", ", assignation_list[3,1])
-    message("")
-    output_assignation_list <-rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
+    if (isTRUE(verbose)) {
+      message("your peak at ",ppm, " probably corresponds to ",assignation_list[1,1], ", ",assignation_list[2,1],", ", assignation_list[3,1])
+      message("")
+    }
+    output_assignation_list <- rbind(output_assignation_list,assignation_list[1:num_proposed_compounds,])
   }
-  output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each=num_proposed_compounds)
+  output_assignation_list$ppm_to_assign <- rep(ppm_to_assign,each = num_proposed_compounds)
   output_assignation_list <- output_assignation_list[order(output_assignation_list$ppm_to_assign),]
   return(output_assignation_list)
 }
-NULL
+
 
 #' The Human Metabolome DataBase multiplet table: cell metabolites normally found in NMR-based metabolomics
 #'

--- a/R/nmr_identify_regions.R
+++ b/R/nmr_identify_regions.R
@@ -18,10 +18,6 @@
 #' @family peak integration functions
 #' @param ppm_to_assign A vector with the ppm regions to assign
 #' @param num_proposed_compounds set the number of proposed metabolites sorted by the number times reported in the HMDB: `HMDB_blood`.
-nmr_identify_regions_blood <- function(vector, ...) {
-  UseMethod("nmr_identify_regions_blood")
-}
-
 nmr_identify_regions_blood <- function(ppm_to_assign, num_proposed_compounds = 3){
   HMDB_blood <- NULL
   utils::data("HMDB_blood", package = "AlpsNMR", envir = environment())
@@ -75,9 +71,6 @@ NULL
 #' @family peak integration functions
 #' @param ppm_to_assign A vector with the ppm regions to assign
 #' @param num_proposed_compounds set the number of proposed metabolites sorted by the number times reported in the HMDB: `HMDB_urine`.
-nmr_identify_regions_urine <- function(vector, ...) {
-  UseMethod("nmr_identify_regions_urine")
-}
 nmr_identify_regions_urine <- function(ppm_to_assign, num_proposed_compounds = 5){
   HMDB_urine <- NULL
   utils::data("HMDB_urine", package = "AlpsNMR", envir = environment())

--- a/man/nmr_identify_regions_blood.Rd
+++ b/man/nmr_identify_regions_blood.Rd
@@ -4,12 +4,15 @@
 \alias{nmr_identify_regions_blood}
 \title{NMR peak identification (plasma/serum samples)}
 \usage{
-nmr_identify_regions_blood(ppm_to_assign, num_proposed_compounds = 3)
+nmr_identify_regions_blood(ppm_to_assign, num_proposed_compounds = 3,
+  verbose = FALSE)
 }
 \arguments{
 \item{ppm_to_assign}{A vector with the ppm regions to assign}
 
 \item{num_proposed_compounds}{set the number of proposed metabolites sorted by the number times reported in the HMDB: \code{HMDB_blood}.}
+
+\item{verbose}{Logical value. Set it to TRUE to print additional information}
 }
 \value{
 a data frame with plausible assignations.

--- a/man/nmr_identify_regions_cell.Rd
+++ b/man/nmr_identify_regions_cell.Rd
@@ -4,12 +4,15 @@
 \alias{nmr_identify_regions_cell}
 \title{NMR peak identification (cell samples)}
 \usage{
-nmr_identify_regions_cell(ppm_to_assign, num_proposed_compounds = 3)
+nmr_identify_regions_cell(ppm_to_assign, num_proposed_compounds = 3,
+  verbose = FALSE)
 }
 \arguments{
 \item{ppm_to_assign}{A vector with the ppm regions to assign}
 
 \item{num_proposed_compounds}{set the number of proposed metabolites in \code{HMDB_cell}.}
+
+\item{verbose}{Logical value. Set it to TRUE to print additional information}
 }
 \value{
 a data frame with plausible assignations.

--- a/man/nmr_identify_regions_urine.Rd
+++ b/man/nmr_identify_regions_urine.Rd
@@ -4,12 +4,15 @@
 \alias{nmr_identify_regions_urine}
 \title{NMR peak identification (urine samples)}
 \usage{
-nmr_identify_regions_urine(ppm_to_assign, num_proposed_compounds = 5)
+nmr_identify_regions_urine(ppm_to_assign, num_proposed_compounds = 5,
+  verbose = FALSE)
 }
 \arguments{
 \item{ppm_to_assign}{A vector with the ppm regions to assign}
 
 \item{num_proposed_compounds}{set the number of proposed metabolites sorted by the number times reported in the HMDB: \code{HMDB_urine}.}
+
+\item{verbose}{Logical value. Set it to TRUE to print additional information}
 }
 \value{
 a data frame with plausible assignations.


### PR DESCRIPTION
The `nmr_identify_regions_*` functions print a lot of information (pages in the tutorial).
While the information is nice for debug purposes, some users may prefer to hide it.

A general good-practice convention is to hide those messages under a `verbose` argument, so the messages are printed only if the user chooses `verbose = TRUE`.

The code has also been slightly simplified, since the functions do not need to be defined as a generic first.