### PR TITLE
Replace GITHUB_TOKEN with DEPLOY_PAT

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,4 +24,4 @@ jobs:
         if: success () && github.ref == 'refs/heads/master'
         run: |
           Rscript -e "remotes::install_local('.')"
-          Rscript -e "pkgdown:::deploy_local(new_process = FALSE, remote_url = 'https://x-access-token:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git')"
+          Rscript -e "pkgdown:::deploy_local(new_process = FALSE, remote_url = 'https://x-access-token:${{secrets.DEPLOY_PAT}}@github.com/${{github.repository}}.git')"


### PR DESCRIPTION
DEPLOY_PAT is a Personal Access Token created by myself and stored under Settings/secrets. Once github has a better fix we will switch to it.