### PR TITLE
FIX: Always choose a number of latent variables.

### DIFF
--- a/R/plsda.R
+++ b/R/plsda.R
@@ -219,13 +219,13 @@ fun_choose_best_ncomp_auc_threshold <-
             dplyr::summarise(ncomp = round(stats::median(.data$ncomp))) %>%
             dplyr::ungroup()
         
-        # Sanity check:
-        if (nrow(nlv) != length(unique(model_performances$cv_outer_iteration))) {
-            print(nlv)
-            stop(
-                "Unexpected error. The number of latent variables could not be determined. Please report this."
-            )
-        }
+        # If a given outer iteration has such bad performance that no number of latent 
+        # variables passes the threshold, keep the simplest model (ncomp = 1)
+        nlv <- tidyr::complete(
+          nlv,
+          cv_outer_iteration = sort(unique(model_performances$cv_outer_iteration)),
+          fill = list(ncomp = 1)
+        )
         
         plot_to_choose_nlv <-
             ggplot2::ggplot(model_performances) +


### PR DESCRIPTION
Very bad models could trigger that no good number of latent variables were selected. Now if that happens, we use the simplest ncomp=1 model.

Feel free to cherry-pick this commit into master as well.