### PR TITLE
Update CI to R 4.6 / Bioc 3.23 and bump all GitHub Actions

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -57,9 +57,9 @@ jobs:
           - {
               os: ubuntu-24.04,
               conf_name: 'ubuntu',
-              r: '4.5',
-              bioc: '3.21',
-              cont: "bioconductor/bioconductor_docker:RELEASE_3_21",
+              r: '4.6',
+              bioc: '3.23',
+              cont: "bioconductor/bioconductor_docker:RELEASE_3_23",
               rspm: "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"
             }
           #- {
@@ -100,7 +100,7 @@ jobs:
       ## https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml
       ## If they update their steps, we will also need to update ours.
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       ## R is already included in the Bioconductor docker images
       - name: Setup R from r-lib
@@ -333,9 +333,9 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v7
         with:
-          name: ${{ runner.os }}-biocversion-RELEASE_3_19-r-4.4-results
+          name: ${{ runner.os }}-biocversion-RELEASE_${{ matrix.config.bioc }}-r-${{ matrix.config.r }}-results
           path: check
 
         ## Note that DOCKER_PASSWORD is really a token for your dockerhub
@@ -344,7 +344,7 @@ jobs:
         ## https://seandavi.github.io/BuildABiocWorkshop/articles/HOWTO_BUILD_WORKSHOP.html#6-add-secrets-to-github-repo
         ## Check https://github.com/docker/build-push-action/tree/releases/v1
         ## for more details.
-      - uses: docker/build-push-action@v1
+      - uses: docker/build-push-action@v7
         if: "!contains(github.event.head_commit.message, '/nodocker') && env.run_docker == 'true' && runner.os == 'Linux' && github.repository == env.pkgdown_repo "
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -232,6 +232,16 @@ jobs:
         continue-on-error: true
         shell: Rscript {0}
 
+      - name: Install BiocStyle fork (pandoc >=3.8.1 uncaptioned-table counter fix)
+        run: |
+          ## Vignette builds fail with recent pandoc versions ("LaTeX Error: No
+          ## counter 'none' defined") because pandoc >=3.8.1 emits \LTcaptype{none}
+          ## for uncaptioned longtables, and BiocStyle's LaTeX template never
+          ## predefines that counter. Use zeehio/BiocStyle@my-fixes until the fix
+          ## lands upstream: https://github.com/Bioconductor/BiocStyle/pull/116
+          remotes::install_github("zeehio/BiocStyle@my-fixes", force = TRUE)
+        shell: Rscript {0}
+
       - name: Install dependencies pass 2
         run: |
           ## Pass #2 at installing dependencies


### PR DESCRIPTION
## Summary

CI on `devel` has been failing (and hadn't run successfully in ~10 months before that) with a LaTeX error while rebuilding `Vig02-handling-metadata-and-annotations.Rmd`:

```
! LaTeX Error: No counter 'none' defined.
```

**Root cause, now confirmed**: pandoc `>=3.8.1` changed how it renders uncaptioned Markdown tables to LaTeX — it now emits `\def\LTcaptype{none}` (a `longtable`/`caption`-package directive meaning "don't use a float counter for this caption"). BiocStyle's LaTeX template never predefines a counter literally named `none`, so LaTeX errors out the first time an uncaptioned table appears. Bisected across pandoc releases: `3.8` builds fine, `3.8.1` is the first broken version, and it's still broken as of the latest release (`3.10`) — so this isn't a "wait for pandoc to fix it" situation.

Minimal reproduction (no AlpsNMR code involved at all — just BiocStyle's standard `pdf_document` output format and a single uncaptioned Markdown table):
```markdown
---
output:
  BiocStyle::pdf_document:
    latex_engine: lualatex
---

| File type | Suggested function     |
| ----------| ---------------------- |
| CSV       | `readr::read_csv()`    |
```
Fails identically with stock BiocStyle 2.40.0 + pandoc >=3.8.1.

## Changes

- **Bioconductor / R version**: `RELEASE_3_21` (R 4.5, Bioc 3.21) → `RELEASE_3_23` (R 4.6, Bioc 3.23), the current Bioconductor release. (This alone does not fix the LaTeX error — see below.)
- **Install `zeehio/BiocStyle@my-fixes`** in the CI workflow, before the dependency-installation pass that builds vignettes. That branch predefines the `none` counter in BiocStyle's LaTeX template (in the correct file, `default-2.8.tex`, at the correct location — before `$body$`). This is a temporary pin until [Bioconductor/BiocStyle#116](https://github.com/Bioconductor/BiocStyle/pull/116) lands upstream.
- **GitHub Actions bumped to current major versions**:
  - `actions/checkout`: v4 → v6
  - `actions/upload-artifact`: `@master` (an unpinned, mutable branch ref) → v7, and the uploaded artifact name now reflects the actual matrix R/Bioc version instead of a hardcoded stale `RELEASE_3_19-r-4.4` string
  - `docker/build-push-action`: v1 → v7
  - `actions/cache` (v4) and `r-lib/actions` (v2) were already current, left unchanged

This branch also includes a merge of Bioconductor's own `devel` history (`github.com/bioc/AlpsNMR`), which had drifted ~10 months ahead with its own automated version-bump commits (4.11.1 → 4.15.0) that hadn't been synced back to this repo.

## Test plan

- [x] Bisected the pandoc regression range (3.8 works, 3.8.1 first fails, 3.10 still fails)
- [x] Reproduced with a minimal standalone reprex against stock BiocStyle 2.40.0
- [x] Verified `zeehio/BiocStyle@my-fixes` fixes the reprex and the real vignette against pandoc 3.1.3, 3.8.2.1, and 3.10 (pandoc 3.8.1 itself still fails with a narrower, distinct empty-counter-name variant of the bug — that release was quickly superseded and isn't covered by this fix)
- [ ] Actual CI run on this PR (pending) — the real end-to-end validation
