### PR TITLE
Fix broken roxygen cross-references to @noRd functions

### DIFF
--- a/R/nmr_detect_peaks_align.R
+++ b/R/nmr_detect_peaks_align.R
@@ -442,10 +442,11 @@ peakList_to_dataframe <- function(nmr_dataset, peakList) {
     out
 }
 
-#' Convert the data frame created by `peakList_to_dataframe()` back to a peakList
+#' Convert a peak data frame back to a peakList
 #' This is required because speaq::dohCluster in nmr_align needs the peakList
 #' @noRd
-#' @param peak_data The peak list returned by `peakList_to_dataframe()`
+#' @param peak_data A data frame with, at least, NMRExperiment and pos columns
+#'        identifying each peak's sample and position
 #' @return a peakList
 #' @importFrom rlang .data
 #' @keywords internal

--- a/R/nmr_detect_peaks_align.R
+++ b/R/nmr_detect_peaks_align.R
@@ -442,10 +442,10 @@ peakList_to_dataframe <- function(nmr_dataset, peakList) {
     out
 }
 
-#' Convert the data frame created by [peakList_to_dataframe] back to a peakList
+#' Convert the data frame created by `peakList_to_dataframe()` back to a peakList
 #' This is required because speaq::dohCluster in nmr_align needs the peakList
 #' @noRd
-#' @param peak_data The peak list returned by [peakList_to_dataframe]
+#' @param peak_data The peak list returned by `peakList_to_dataframe()`
 #' @return a peakList
 #' @importFrom rlang .data
 #' @keywords internal

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -228,7 +228,7 @@ choose_best_nlv_impl <- function(ncomp_auc, auc_threshold) {
 }
 
 #' Choose best number of latent variables based on a threshold on the auc increment.
-#' @param inner_cv_results A list of elements returned by [callback_plsda_auroc_vip]
+#' @param inner_cv_results A list of elements returned by `callback_plsda_auroc_vip()`
 #' @param auc_threshold Threshold on the increment of AUC. Increasing the number of
 #' latent variables must increase the AUC at least by this threshold.
 #' @return A list with:

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -228,7 +228,7 @@ choose_best_nlv_impl <- function(ncomp_auc, auc_threshold) {
 }
 
 #' Choose best number of latent variables based on a threshold on the auc increment.
-#' @param inner_cv_results A list of elements returned by `callback_plsda_auroc_vip()`
+#' @param inner_cv_results A list of elements, each containing at least an `auroc` field
 #' @param auc_threshold Threshold on the increment of AUC. Increasing the number of
 #' latent variables must increase the AUC at least by this threshold.
 #' @return A list with:


### PR DESCRIPTION
## Summary

`devtools::document()` flagged two broken links:

```
x nmr_detect_peaks_align.R:445: @title Could not resolve link to topic "peakList_to_dataframe" ...
x nmr_detect_peaks_align.R:448: @param Could not resolve link to topic "peakList_to_dataframe" ...
x plsda.R:231: @param Could not resolve link to topic "callback_plsda_auroc_vip" ...
```

Both `peakList_to_dataframe()` and `callback_plsda_auroc_vip()` are internal helpers tagged `@noRd`, so roxygen2 never generates a help topic for them — the markdown-style `[function]` links elsewhere in their docs could therefore never resolve.

Checked the rest of the codebase before deciding how to fix this: `@noRd` (no help page at all) is the dominant convention for internal implementation helpers here (~30 functions across `bruker.R`, `import_jdx.R`, `nmr_data_analysis.R`, `nmr_peak_clustering.R`, `plsda.R`, `utils.R`, etc.), versus exactly one existing function (`read_bruker_pdata`) that's internal-but-documented (`@keywords internal` without `@noRd`). `peakList_to_dataframe()`/`callback_plsda_auroc_vip()` are low-level, single-file-only helpers that fit the `@noRd` category, so rather than exposing new help topics just to make the links resolve, the two `@param`/`@title` lines that referenced them now describe the expected data shape directly instead of naming the other internal function at all.

## Changes

- `R/nmr_detect_peaks_align.R`: `peak_data_to_peakList()`'s docs now describe `peak_data`'s expected columns (`NMRExperiment`, `pos`) instead of linking to `peakList_to_dataframe()`.
- `R/plsda.R`: `choose_best_nlv()`'s docs now describe `inner_cv_results`'s expected shape (a list of elements each containing an `auroc` field) instead of linking to `callback_plsda_auroc_vip()`.

## Test plan

- [x] `devtools::document()` runs with no "Could not resolve link" warnings
- [x] Both files parse cleanly


---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_