### PR TITLE
Fix bp_VIP_analysis: use the cumulative Eq.9 VIP column instead of re-aggregating across components

### DIFF
--- a/R/nmr_data_analysis.R
+++ b/R/nmr_data_analysis.R
@@ -702,10 +702,12 @@ bp_VIP_analysis <- function(dataset,
                     identity = NULL,
                     ncomp = ncomp
                 )
-            # VIPs per component extraction
+            # VIPs per component extraction. mixOmics::vip() already returns,
+            # in column h, the cumulative VIP (Eq. 9 of Afanador et al. 2013)
+            # computed over components 1..h, so the last column (h = ncomp)
+            # is the VIP of the fitted model.
             pls_vip_comps <- plsda_vip(model)
-            # Sum contributions of VIPs to each component
-            pls_vip <- sqrt(rowSums(pls_vip_comps^2) / ncomp)
+            pls_vip <- pls_vip_comps[, ncomp]
             # Measure the classification rate (CR) of the bootstrap model
             CR <- get_test_accuracy(model, x_test, y_test)
             pls_vip_perm <- matrix(nrow = n, ncol = n, dimnames = list(names, NULL))
@@ -726,10 +728,11 @@ bp_VIP_analysis <- function(dataset,
                         identity = NULL,
                         ncomp = ncomp
                     )
-                # VIPs per component extraction
+                # VIPs per component extraction (see note above: take the
+                # cumulative VIP through component ncomp, not a re-aggregation
+                # across components).
                 pls_vip_comps_perm <- plsda_vip(model_perm)
-                # Sum contributions of VIPs to each component
-                pls_vip_perm[, j] <- sqrt(rowSums(pls_vip_comps_perm^2) / ncomp)
+                pls_vip_perm[, j] <- pls_vip_comps_perm[, ncomp]
             }
             # bootsrapped and randomly permuted PLS-VIPs
             pls_vip_perm_score <- colSums(pls_vip_perm) / n

--- a/tests/testthat/test-nmr-data-analysis.R
+++ b/tests/testthat/test-nmr-data-analysis.R
@@ -182,6 +182,76 @@ test_that("bp_VIP_analysis identifies a strongly predictive feature as relevant"
     expect_gt(means["V1"], max(means[setdiff(names(means), "V1")]))
 })
 
+test_that("bp_VIP_analysis uses the ncomp-th (cumulative) VIP column, not a re-aggregation across components", {
+    # mixOmics::vip() returns, in its column h, the VIP already computed
+    # cumulatively over components 1..h (Eq. 9 of Afanador, Tran & Buydens,
+    # 2013). bp_VIP_analysis() must therefore take column `ncomp` as-is; it
+    # must not re-aggregate the per-component columns (e.g. via
+    # sqrt(rowSums(x^2) / ncomp)), which would apply Eq. 9's normalization a
+    # second time to already-normalized quantities.
+    #
+    # plsda_vip() is mocked to return an (almost) fixed, easily distinguished
+    # matrix regardless of the fitted model (a small jitter is added so the
+    # across-bootstrap variance used later isn't degenerately zero), so the
+    # two candidate formulas produce numerically distinct, checkable
+    # results: taking column `ncomp` (2) gives approximately c(10, 20, 30,
+    # 40), while sqrt(rowSums(x^2) / 2) would instead give approximately
+    # sqrt(c(101, 404, 909, 1616) / 2) ~= c(7.1, 14.2, 21.3, 28.4).
+    skip_if_not_installed("mixOmics")
+    skip_if_not_installed("BiocParallel")
+
+    old_bpparam <- BiocParallel::bpparam()
+    BiocParallel::register(BiocParallel::SerialParam())
+    on.exit(BiocParallel::register(old_bpparam), add = TRUE)
+
+    p <- 4
+    base_vip <- matrix(
+        c(1, 2, 3, 4, 10, 20, 30, 40),
+        nrow = p, ncol = 2,
+        dimnames = list(paste0("V", seq_len(p)), NULL)
+    )
+    # A little call-to-call jitter keeps each bootstrap replicate's
+    # VIP-difference distribution non-degenerate (bp_VIP_analysis() divides
+    # by its across-replicate standard deviation), without disturbing which
+    # of the two candidate formulas the assertion below distinguishes.
+    testthat::local_mocked_bindings(
+        plsda_vip = function(plsda_model) base_vip + stats::rnorm(length(base_vip), sd = 0.01)
+    )
+
+    set.seed(1)
+    n <- 20
+    y <- factor(rep(c("A", "B"), each = n / 2))
+    x <- matrix(rnorm(n * p), nrow = n, ncol = p)
+    colnames(x) <- paste0("V", seq_len(p))
+
+    metadata <- data.frame(
+        NMRExperiment = as.character(seq_len(n)),
+        Condition = y
+    )
+    dataset <- new_nmr_dataset_peak_table(
+        peak_table = x,
+        metadata = list(external = metadata)
+    )
+    train_index <- c(1:7, 11:17) # both classes in train (1:7, 11:17) and test (8:10, 18:20)
+
+    result <- suppressWarnings(bp_VIP_analysis(
+        dataset,
+        train_index,
+        y_column = "Condition",
+        ncomp = 2,
+        nbootstrap = 3
+    ))
+
+    expected <- base_vip[, 2]
+    for (feature in names(expected)) {
+        expect_equal(
+            unname(result$pls_vip[feature, ]),
+            rep(expected[[feature]], 3),
+            tolerance = 0.1
+        )
+    }
+})
+
 test_that("bp_VIP_analysis shuffles each feature's own column when building its permutation baseline", {
     # Each feature's own values must be shuffled independently, not swapped
     # for another feature's values, or the permutation-importance baseline


### PR DESCRIPTION
## Summary

`bp_VIP_analysis()` (`R/nmr_data_analysis.R`) implements the BP-VIP method of Afanador, Tran & Buydens, *Analytica Chimica Acta* 768 (2013) 49–56. This PR fixes one discrepancy between the paper's definition of the PLS-VIP statistic and the way the code extracts it from `mixOmics::vip()`.

## What the paper specifies

Eq. (9) defines the VIP of the *j*th predictor variable for an *h*-component PLS model:

> VIP<sub>j</sub> = √( p · Σ<sub>k=1</sub><sup>h</sup> (ĉ<sub>k</sub>² t<sub>k</sub>′t<sub>k</sub>)(w<sub>jk</sub>)² ⁄ Σ<sub>k=1</sub><sup>h</sup> ĉ<sub>k</sub>² t<sub>k</sub>′t<sub>k</sub> )

and immediately after: "The average of the squared PLS-VIP scores is equal to one; hence the 'VIP scores greater than one' rule is generally used as the criterion for important variable selection." This normalization property (Σ<sub>j</sub> VIP<sub>j</sub>² / p = 1) holds for the *single* h-component VIP vector produced by Eq. (9) — it is not something that should be re-derived by combining several already-normalized VIP vectors.

Step (3) of the BP-VIP procedure (Section 2.4) is likewise explicit that a bootstrap replicate contributes exactly one VIP value per predictor: "PLS models are fit to each of the bootstrap datasets using the number of PLS components determined in Step 1, **and the PLS-VIP for each predictor variable is obtained**." There is no subsequent step that combines per-component VIPs.

## Current code behaviour, and why it is wrong

`plsda_vip()` (`R/plsda.R`) is a thin wrapper that returns `mixOmics::vip(plsda_model)` unmodified. `mixOmics::vip()` returns a `p × H` matrix whose column `h` is *already* the full Eq. (9) statistic computed with the sum running over `k = 1..h` — i.e. column `H` (`H = ncomp`) is precisely the paper's VIP<sub>j</sub> for the fitted `ncomp`-component model. This can be verified both from the `mixOmics::vip()` source (`VIP[, h] = Rd %*% t(W[, 1:h]^2) / sum(Rd)`, `Rd = cor2[, 1:h]`, followed by `VIP = sqrt(p * VIP)`) and empirically: for any fitted model, `colMeans(mixOmics::vip(model)^2)` returns a vector of ones, one per column — reproducing the paper's stated normalization property for *every* column, not just the last.

Prior to this fix, `bp_VIP_analysis()` did not use this column directly. Instead it computed:

```r
pls_vip_comps <- plsda_vip(model)
pls_vip <- sqrt(rowSums(pls_vip_comps^2) / ncomp)
```

i.e. it re-aggregated *all* `ncomp` columns of an already Eq.-9-normalized matrix through a second, ad hoc square-root-mean-of-squares. Because each column already satisfies Σ<sub>j</sub> VIP<sub>j</sub>[,k]² / p = 1, this is mathematically a normalization applied twice: once inside `mixOmics::vip()` (correctly, per Eq. 9, cumulative over components 1..k) and once again by averaging across `k`. The result is not the quantity defined by Eq. (9) for the `ncomp`-component model, and it also does not preserve the "average squared VIP equals one" property the paper relies on for the "VIP > 1" interpretation — e.g. for `ncomp = 2` the average of the squared `pls_vip` values is `mean(rowSums(V^2))/ncomp` rather than 1, biasing the score (typically downward) relative to Eq. (9) and shifting the significance thresholds computed downstream (Section 2.4, steps 5–6) away from their intended calibration. The same bug is present in the permutation branch, which repeats the identical re-aggregation.

## Proposed fix, and why it is correct

Replace both occurrences with a direct column selection:

```r
pls_vip_comps <- plsda_vip(model)
pls_vip <- pls_vip_comps[, ncomp]
```

Column `ncomp` of `mixOmics::vip()`'s output *is* Eq. (9)'s VIP<sub>j</sub> for the fitted `ncomp`-component model (sum over `k = 1..ncomp`, as required) — no further transformation is needed or licensed by the paper. This also restores the "average of the squared PLS-VIP scores is equal to one" invariant the paper states directly beneath Eq. (9), which the pre-existing code silently violated for any `ncomp > 1`.

## Testing

Added a regression test (`test-nmr-data-analysis.R`) that mocks `plsda_vip()` to return a fixed, per-component-distinguishable matrix and checks that `bp_VIP_analysis()` (`ncomp = 2`) surfaces column `ncomp` verbatim. Verified against the pre-fix code that the test fails with the exact values the old `sqrt(rowSums(x^2)/ncomp)` formula predicts (e.g. `7.10` instead of the expected `10`), confirming the test discriminates between the two formulas. Full existing suite (`devtools::test()`) passes unchanged, since all pre-existing `bp_VIP_analysis` tests use `ncomp = 1`, for which the two formulas coincide (`sqrt(x[,1]^2/1) == x[,1]` for non-negative VIPs).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_