### PR TITLE
Fix bp_VIP_analysis: permutation VIP baseline must use the permuted feature's own (diagonal) VIP

### DIFF
--- a/R/nmr_data_analysis.R
+++ b/R/nmr_data_analysis.R
@@ -652,7 +652,7 @@ bp_VIP_analysis <- function(dataset,
         stop("Only one class in test set, please increase number of samples")
     }
 
-    num_features <- n <- ncol(x_all)
+    num_features <- ncol(x_all)
     
     if (ncomp > num_features) {
         cli::cli_abort("ncomp ({ncomp}) can't be larger than num_features ({num_features})")
@@ -710,9 +710,12 @@ bp_VIP_analysis <- function(dataset,
             pls_vip <- pls_vip_comps[, ncomp]
             # Measure the classification rate (CR) of the bootstrap model
             CR <- get_test_accuracy(model, x_test, y_test)
-            pls_vip_perm <- matrix(nrow = n, ncol = n, dimnames = list(names, NULL))
 
-            # Permutation of variables
+            # bootsrapped and randomly permuted PLS-VIPs: for each feature j,
+            # take its own VIP from the model fit with feature j (and only
+            # feature j) permuted, rather than averaging feature j's VIP
+            # across all num_features permuted-feature models.
+            pls_vip_perm_score <- stats::setNames(numeric(num_features), names)
             for (j in seq_len(num_features)) {
                 x_train_boots_perm <- x_train_boots
                 # Shuffle column j's own values (breaks its row-order
@@ -732,14 +735,8 @@ bp_VIP_analysis <- function(dataset,
                 # cumulative VIP through component ncomp, not a re-aggregation
                 # across components).
                 pls_vip_comps_perm <- plsda_vip(model_perm)
-                pls_vip_perm[, j] <- pls_vip_comps_perm[, ncomp]
+                pls_vip_perm_score[j] <- pls_vip_comps_perm[j, ncomp]
             }
-            # bootsrapped and randomly permuted PLS-VIPs: for each feature j,
-            # take its own VIP from the model fit with feature j (and only
-            # feature j) permuted -- i.e. pls_vip_perm[j, j] -- rather than
-            # averaging feature j's column across all n permuted-feature
-            # models.
-            pls_vip_perm_score <- diag(pls_vip_perm)
 
             # bootsrapped and randomly permuted difference
             pls_vip_score_diff <- pls_vip - pls_vip_perm_score

--- a/R/nmr_data_analysis.R
+++ b/R/nmr_data_analysis.R
@@ -734,8 +734,12 @@ bp_VIP_analysis <- function(dataset,
                 pls_vip_comps_perm <- plsda_vip(model_perm)
                 pls_vip_perm[, j] <- pls_vip_comps_perm[, ncomp]
             }
-            # bootsrapped and randomly permuted PLS-VIPs
-            pls_vip_perm_score <- colSums(pls_vip_perm) / n
+            # bootsrapped and randomly permuted PLS-VIPs: for each feature j,
+            # take its own VIP from the model fit with feature j (and only
+            # feature j) permuted -- i.e. pls_vip_perm[j, j] -- rather than
+            # averaging feature j's column across all n permuted-feature
+            # models.
+            pls_vip_perm_score <- diag(pls_vip_perm)
 
             # bootsrapped and randomly permuted difference
             pls_vip_score_diff <- pls_vip - pls_vip_perm_score

--- a/tests/testthat/test-nmr-data-analysis.R
+++ b/tests/testthat/test-nmr-data-analysis.R
@@ -159,18 +159,21 @@ test_that("bp_VIP_analysis identifies a strongly predictive feature as relevant"
 
     # bp_VIP_analysis() emits an informational cli_warn() when few VIPs
     # clear the "important" (stricter) threshold with so few bootstraps;
-    # that is expected/benign with nbootstrap = 5, so it is suppressed here.
+    # that is expected/benign here, so it is suppressed. nbootstrap = 30 (as
+    # opposed to a handful) keeps the per-feature bootstrap standard
+    # deviation used to standardize the VIP-score difference (see the paper's
+    # Eq. (13)/step 6) from being dominated by noise on this tiny dataset.
     result <- suppressWarnings(bp_VIP_analysis(
         dataset,
         train_index,
         y_column = "Condition",
         ncomp = 1,
-        nbootstrap = 5 # kept tiny for test speed
+        nbootstrap = 30 # kept small for test speed
     ))
 
     # Expected shape: num_features x nbootstrap matrices
-    expect_equal(dim(result$pls_vip), c(p, 5))
-    expect_equal(dim(result$pls_vip_perm), c(p, 5))
+    expect_equal(dim(result$pls_vip), c(p, 30))
+    expect_equal(dim(result$pls_vip_perm), c(p, 30))
     expect_setequal(rownames(result$pls_vip_means), colnames(x))
 
     # The informative feature is (the only feature) flagged as relevant:
@@ -247,6 +250,67 @@ test_that("bp_VIP_analysis uses the ncomp-th (cumulative) VIP column, not a re-a
         expect_equal(
             unname(result$pls_vip[feature, ]),
             rep(expected[[feature]], 3),
+            tolerance = 0.1
+        )
+    }
+})
+
+test_that("bp_VIP_analysis's permutation score for feature j is feature j's own VIP in the j-permuted model", {
+    # Per the paper's steps (4)-(5) (Section 2.4), the permutation baseline
+    # used for feature j's importance must be feature j's own VIP value in
+    # the model fit with (only) feature j permuted -- the diagonal entry
+    # pls_vip_perm[j, j] -- not an average of feature j's VIP across the p
+    # separate permuted-feature models.
+    #
+    # plsda_vip() is mocked so its return value depends only on the position
+    # of the call within a bootstrap iteration: the first call (the
+    # un-permuted model) returns a fixed vector, and the k-th call inside the
+    # permutation loop (the model with feature k permuted) returns
+    # 10*k + m for feature m, so the diagonal (m == k) is numerically
+    # distinguishable from a column mean. A small jitter keeps the
+    # across-bootstrap variance non-degenerate.
+    skip_if_not_installed("mixOmics")
+    skip_if_not_installed("BiocParallel")
+
+    old_bpparam <- BiocParallel::bpparam()
+    BiocParallel::register(BiocParallel::SerialParam())
+    on.exit(BiocParallel::register(old_bpparam), add = TRUE)
+
+    p <- 4
+    call_count <- 0L
+    testthat::local_mocked_bindings(
+        plsda_vip = function(plsda_model) {
+            call_count <<- call_count + 1L
+            pos <- (call_count - 1L) %% (p + 1L)
+            base_vip <- if (pos == 0L) {
+                c(100, 200, 300, 400) # the un-permuted bootstrap model
+            } else {
+                10 * pos + seq_len(p) # model with feature `pos` permuted
+            }
+            vip <- base_vip + stats::rnorm(p, sd = 0.01)
+            matrix(vip, nrow = p, ncol = 1, dimnames = list(paste0("V", seq_len(p)), NULL))
+        }
+    )
+
+    set.seed(1)
+    n <- 20
+    y <- factor(rep(c("A", "B"), each = n / 2))
+    x <- matrix(rnorm(n * p), nrow = n, ncol = p)
+    colnames(x) <- paste0("V", seq_len(p))
+    metadata <- data.frame(NMRExperiment = as.character(seq_len(n)), Condition = y)
+    dataset <- new_nmr_dataset_peak_table(peak_table = x, metadata = list(external = metadata))
+    train_index <- c(1:7, 11:17) # both classes in train (1:7, 11:17) and test (8:10, 18:20)
+
+    result <- suppressWarnings(bp_VIP_analysis(
+        dataset, train_index,
+        y_column = "Condition", ncomp = 1, nbootstrap = 3
+    ))
+
+    expected_perm_score <- c(V1 = 11, V2 = 22, V3 = 33, V4 = 44)
+    for (feature in names(expected_perm_score)) {
+        expect_equal(
+            unname(result$pls_vip_perm[feature, ]),
+            rep(expected_perm_score[[feature]], 3),
             tolerance = 0.1
         )
     }


### PR DESCRIPTION
## Summary

`bp_VIP_analysis()` (`R/nmr_data_analysis.R`) implements the BP-VIP method of Afanador, Tran & Buydens, *Analytica Chimica Acta* 768 (2013) 49–56. This PR fixes the extraction of the permutation-based VIP baseline that the method's matched-pairs statistic is built from — the most consequential of the three discrepancies found between the paper and this function, since it corrupts the null distribution used for every feature's significance test.

## What the paper specifies

Section 2.4 ("Permutation procedure") states the rationale directly:

> "The rationale behind randomly permuting each predictor variable is that its original relationship with the response variable is disrupted. If the permuted variable is important it is expected that the PLS-VIP value will decrease[] substantially. Thus, a reasonable measure for variable importance is the difference between the actual PLS-VIP and **the randomly permuted PLS-VIP**. [...] capturing **the permuted variable[']s PLS-VIP**, and comparing this to the original PLS-VIP, via measuring its difference, generates the analogue of a matched pairs analysis."

and the six-step BP-VIP algorithm makes the pairing explicit:

> "(4) Immediately following Step 3, randomly permute each variable in turn and re-fit PLS models to the modified dataset, where each variable is randomly permuted in sequence within each bootstrap dataset.
> (5) Calculate the PLS-VIP score difference between the non-permuted bootstrap variable (Step 3) and the randomly permuted bootstrap dataset for that variable (Step 4)."

For predictor *j*, step (4) fits one model with *only* variable *j* permuted, and step (5) requires the difference to be taken *for that variable* — i.e. between VIP<sub>j</sub> from the non-permuted model and VIP<sub>j</sub> from the model in which variable *j* (specifically) was permuted. This is exactly the "matched pairs" structure the paper names: each feature is paired only with its own permutation outcome, never with another feature's.

## Current code behaviour, and why it is wrong

Inside the bootstrap loop, the code fits `num_features` permuted models — one per feature `j` — and stores each model's full VIP vector in column `j` of a `p × p` matrix:

```r
pls_vip_perm <- matrix(nrow = n, ncol = n, dimnames = list(names, NULL))
for (j in seq_len(num_features)) {
    x_train_boots_perm <- x_train_boots
    x_train_boots_perm[, j] <- sample(x_train_boots[, j])
    model_perm <- plsda_build(x = x_train_boots_perm, y = y_train_boots, identity = NULL, ncomp = ncomp)
    pls_vip_comps_perm <- plsda_vip(model_perm)
    pls_vip_perm[, j] <- ...   # VIP of *every* feature, from the model with feature j permuted
}
pls_vip_perm_score <- colSums(pls_vip_perm) / n
```

`pls_vip_perm[, j]` is the VIP of *every* feature `m = 1..p` computed from the model where feature `j` was permuted; entry `pls_vip_perm[j, j]` is feature `j`'s own VIP in its own permuted model, which is what step (5) calls for. Instead, `pls_vip_perm_score <- colSums(pls_vip_perm) / n` averages *all p rows* of column `j` — i.e. it averages feature `j`'s VIP together with every *other*, unrelated feature's VIP from that same permuted-`j` model, and uses that average as feature `j`'s permutation baseline.

This breaks the paired-difference structure the paper explicitly relies on ("the analogue of a matched pairs analysis"): the baseline subtracted from feature `j`'s VIP is no longer feature `j`'s own value under permutation, but a population mean over all features' VIPs (dominated by the `p − 1` *other* features, unrelated to `j`'s permutation). Since `mixOmics::vip()` VIPs average to a constant (Σ VIP² / p = 1 per Eq. 9, so the column mean of `pls_vip_perm[, j]` is roughly stable near ~1 regardless of which feature was permuted), `pls_vip_perm_score` ends up close to the *same* value for every feature `j`, largely independent of whether `j` itself was actually informative under permutation. This collapses the per-feature null distribution the matched-pairs test depends on, and biases `pls_vip_score_diff` (and everything derived from it downstream: `boots_vip`, the confidence bounds, `important_vips`, `relevant_vips`) toward whatever separates `pls_vip[j]` from a roughly-constant population average, rather than from feature `j`'s own permutation outcome.

## Proposed fix, and why it is correct

```r
pls_vip_perm_score <- diag(pls_vip_perm)
```

`pls_vip_perm[j, j]` is precisely "the permuted variable[']s PLS-VIP" for variable `j` that steps (4)–(5) define: the VIP of feature `j`, taken from the one model in which feature `j` (and only feature `j`) was permuted. Taking the diagonal restores the one-to-one matched pairing between `pls_vip[j]` (feature `j`'s VIP, non-permuted) and `pls_vip_perm_score[j]` (feature `j`'s VIP, permuted) that Eq. (14)'s hypothesis `H0: x_j ⊥ y, Z` and the paper's matched-pairs framing require.

## Testing

Added a regression test (`test-nmr-data-analysis.R`) that mocks `plsda_vip()` so its return value is a deterministic function of *which* permuted model is being scored (position `k` in the permutation loop returns `10*k + m` for feature `m`), making the diagonal entry (`11k`) numerically distinguishable from the column mean (`10k + 2.5`) that the old code computed. Verified against the pre-fix code that the test fails with exactly the column-mean-predicted value (`12.5` instead of the expected `11`). The first existing `bp_VIP_analysis` test (which asserts a strongly predictive feature is flagged "relevant") is updated from `nbootstrap = 5` to `nbootstrap = 30`: the corrected permutation baseline is a per-feature quantity with genuine sampling variance (unlike the near-constant population-average it replaces), so a handful of bootstrap replicates is no longer enough to reliably standardize the VIP-score difference on this tiny synthetic dataset — this is expected given the fix, not a sign of instability. Full existing suite (`devtools::test()`) passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_