### PR TITLE
Fix bp_VIP_analysis's significance threshold: use n_samples - 1 degrees of freedom, not nbootstrap - 1

### DIFF
--- a/R/nmr_data_analysis.R
+++ b/R/nmr_data_analysis.R
@@ -641,6 +641,7 @@ bp_VIP_analysis <- function(dataset,
     y_all <- nmr_meta_get_column(dataset, column = y_column)
     x_train <- x_all[train_index, , drop = FALSE]
     y_train <- y_all[train_index]
+    n_samples <- nrow(x_train)
     # For check performance
     x_test <- x_all[-train_index, , drop = FALSE]
     y_test <- y_all[-train_index]
@@ -776,18 +777,18 @@ bp_VIP_analysis <- function(dataset,
         element <- pls_vip_score_diff[k, ] / sd(pls_vip_score_diff[k, ])
         boots_vip[k] <- sum(element) / nbootstrap
         boots_vip_sd[k] <- sqrt(sum((element - boots_vip[k])^2) / (nbootstrap - 1))
-        error[k] <- qt(0.975, df = nbootstrap - 1) * boots_vip_sd[k]
+        error[k] <- qt(0.975, df = n_samples - 1) * boots_vip_sd[k]
         lower_bound[k] <- boots_vip[k] - error[k]
         upper_bound[k] <- boots_vip[k] + error[k]
     }
 
-    # NOTE: this compares a CI-adjusted lower bound against a raw t-critical
-    # value; verify intended semantics (see the "more stringent subset"
-    # comment in train_models_with_only_vip_features() and the deprecated
-    # vip_means-2*error criterion below in bp_kfold_VIP_analysis(), which
-    # suggest important_vips is meant to use a different/stricter, but not
-    # necessarily this, threshold than relevant_vips).
-    important_vips <- names[lower_bound > qt(0.975, df = nbootstrap - 1)]
+    # The "important" threshold is the same t_{1-alpha/2, n-1} quantile used
+    # to build the confidence interval above (n = number of training
+    # samples, not the number of bootstrap datasets): a variable is
+    # "important" when its entire two-sided (1-alpha) confidence interval
+    # lies above that quantile, and merely "marginally important"
+    # (relevant_vips) when its lower bound clears zero.
+    important_vips <- names[lower_bound > qt(0.975, df = n_samples - 1)]
     relevant_vips <- names[lower_bound > 0]
 
     # Checking performance

--- a/tests/testthat/test-nmr-data-analysis.R
+++ b/tests/testthat/test-nmr-data-analysis.R
@@ -316,6 +316,69 @@ test_that("bp_VIP_analysis's permutation score for feature j is feature j's own 
     }
 })
 
+test_that("bp_VIP_analysis's significance threshold uses df = n_samples - 1, not df = nbootstrap - 1", {
+    # Afanador, Tran & Buydens (2013) calculate the 95% confidence interval
+    # for the (per-feature) standardized VIP-score difference by multiplying
+    # its bootstrap standard deviation by "the appropriate quantile,
+    # t_{1-alpha/2,n-1}" (text following Eqs. (12)-(13); the same quantile is
+    # reused verbatim for the "Important" cut-off in the guidelines list of
+    # Section 2.3). Throughout the paper, n denotes the number of *training
+    # samples* the model was fit on (e.g. "VACCINE data set with n = 50" in
+    # Section 3.6) -- not B, the number of bootstrap datasets (nbootstrap in
+    # this code; B = 300 for the paper's own experiments). This is confirmed
+    # numerically by the paper's own worked example: for the VACCINE
+    # dataset (n = 50 training samples, B = 300 bootstraps), the text reports
+    # the cut-off as "2.01 (t_{1-alpha/2,n-1})" -- which is qt(0.975, df = 49)
+    # = 2.0096, not qt(0.975, df = 299) = 1.9679.
+    #
+    # Because `element <- pls_vip_score_diff[k, ] / sd(pls_vip_score_diff[k, ])`
+    # standardizes each feature's difference vector to its own sample
+    # standard deviation, boots_vip_sd[k] (recomputed from `element` with the
+    # same n-1 estimator) is analytically always 1, so
+    # result$error[k] == qt(0.975, df = <whatever df is used>) exactly,
+    # independent of the (random) bootstrap data. This lets the two
+    # candidate degrees of freedom be told apart without any mocking.
+    skip_if_not_installed("mixOmics")
+    skip_if_not_installed("BiocParallel")
+
+    old_bpparam <- BiocParallel::bpparam()
+    BiocParallel::register(BiocParallel::SerialParam())
+    on.exit(BiocParallel::register(old_bpparam), add = TRUE)
+
+    set.seed(1)
+    n <- 20
+    p <- 4
+    y <- factor(rep(c("A", "B"), each = n / 2))
+    x <- matrix(rnorm(n * p), nrow = n, ncol = p)
+    colnames(x) <- paste0("V", seq_len(p))
+    x[y == "A", 1] <- x[y == "A", 1] + 8
+
+    metadata <- data.frame(
+        NMRExperiment = as.character(seq_len(n)),
+        Condition = y
+    )
+    dataset <- new_nmr_dataset_peak_table(
+        peak_table = x,
+        metadata = list(external = metadata)
+    )
+    train_index <- c(1:5, 11:15) # n_samples = 10, both classes in train and test
+    nbootstrap <- 20 # deliberately != n_samples, so the two df choices disagree
+
+    result <- suppressWarnings(bp_VIP_analysis(
+        dataset,
+        train_index,
+        y_column = "Condition",
+        ncomp = 1,
+        nbootstrap = nbootstrap
+    ))
+
+    n_samples <- length(train_index)
+    expected_error <- qt(0.975, df = n_samples - 1)
+    wrong_error <- qt(0.975, df = nbootstrap - 1)
+    expect_false(isTRUE(all.equal(expected_error, wrong_error)))
+    expect_equal(unname(result$error[, 1]), rep(expected_error, p))
+})
+
 test_that("bp_VIP_analysis shuffles each feature's own column when building its permutation baseline", {
     # Each feature's own values must be shuffled independently, not swapped
     # for another feature's values, or the permutation-importance baseline


### PR DESCRIPTION
## Summary

`bp_VIP_analysis()` (`R/nmr_data_analysis.R`) implements the BP-VIP method of Afanador, Tran & Buydens, *Analytica Chimica Acta* 768 (2013) 49–56. This PR fixes the degrees of freedom used for the Student-*t* quantile that defines both the 95% confidence interval and the "important variable" significance threshold.

## What the paper specifies

Section 2.3 ("Bootstrapping procedure") gives the bootstrap estimate and its standard deviation (Eqs. (12)–(13); *B* is the number of bootstrap datasets):

> θ̂\* = Σθ̂\*<sup>b</sup> / B  (12)
>
> δ̂<sub>b</sub> = [ Σ<sub>b=1</sub><sup>B</sup> (θ̂\*<sup>b</sup> − θ̂\*)² / (B − 1) ]<sup>1/2</sup>  (13)
>
> "where θ̂\* = VIP<sub>j</sub>, δ̂<sub>b</sub> = δ̂<sub>vip<sub>j</sub></sub>, and *j* = *j*th predictor variable; **95% confidence intervals are calculated by multiplying δ̂<sub>b</sub> by the appropriate quantile, t<sub>1−α/2,n−1</sub>**."

Note that Eq. (13)'s *standard deviation* itself is correctly computed over the *B* bootstrap replicates (denominator `B − 1`), but the *t*-quantile used to turn that standard deviation into a confidence interval is stated to use `n − 1`, not `B − 1`. Throughout the paper, *n* denotes the number of training samples the model is fit on, not the number of bootstrap datasets or predictors — e.g. Section 3.6: "VACCINE dataset with **n = 50**, y = 1, p = 67 (training dataset)." The importance guidelines (Section 2.3) reuse the *same* quantile for the "Important" cut-off:

> "95% confidence interval lower-bound > t<sub>1−α/2,n−1</sub> = Important."

Section 5.1 gives a fully worked, numerically checkable instance of this: for the VACCINE dataset (*n* = 50 training samples, *B* = 300 bootstrap datasets, per Section 3), "we find that two variables, namely C_CONC and S_E, meet the BP-VIP criterion for the standardized differences not [to] encompass **2.01** (t<sub>1−α/2,n−1</sub>)." This value pins down the intended degrees of freedom unambiguously:

```r
qt(0.975, df = 50 - 1)   # n_samples - 1  = 2.0096  ~= 2.01  (matches the paper)
qt(0.975, df = 300 - 1)  # nbootstrap - 1 = 1.9679         (does not match)
```

## Current code behaviour, and why it is wrong

```r
error[k] <- qt(0.975, df = nbootstrap - 1) * boots_vip_sd[k]
...
important_vips <- names[lower_bound > qt(0.975, df = nbootstrap - 1)]
```

Both `qt()` calls use `df = nbootstrap - 1` — the number of bootstrap datasets (default 300, matching *B* in Eq. (13)) — as the degrees of freedom for the confidence-interval quantile. As shown above, `nbootstrap - 1` is the correct denominator for Eq. (13)'s *standard deviation* estimate, but the paper's own text and worked example both use `n − 1`, the number of *training samples*, for the *t*-quantile itself. Conflating the two silently miscalibrates both the confidence interval width and the "important" cut-off whenever `nbootstrap` (typically in the hundreds) differs from the training sample size `n` (typically far smaller, e.g. 50 in the paper's own VACCINE example) — which is essentially always, since `nbootstrap` is a user-chosen algorithm parameter unrelated to dataset size. Because `qt(0.975, df)` is a decreasing function of `df`, and `nbootstrap` is normally much larger than `n_samples`, this bug systematically makes the interval *narrower* and the "important" bar *lower* than the paper intends, for typical parameter choices.

## Proposed fix, and why it is correct

Introduce `n_samples <- nrow(x_train)` (the number of training samples, matching the paper's *n*) and use it as the quantile's degrees of freedom in both places:

```r
error[k] <- qt(0.975, df = n_samples - 1) * boots_vip_sd[k]
...
important_vips <- names[lower_bound > qt(0.975, df = n_samples - 1)]
```

`n_samples - 1` is exactly the degrees of freedom the paper specifies in the text following Eqs. (12)–(13) and reuses for the "Important" guideline, and reproduces the paper's own reported cut-off value (2.01) for its worked example. `boots_vip_sd[k]`'s own computation (denominator `nbootstrap - 1`, per Eq. (13)) is left untouched, since that part of the code already matches the paper.

## Testing

Added a regression test (`test-nmr-data-analysis.R`) that exploits an algebraic invariant of the existing standardization step: because `element <- pls_vip_score_diff[k, ] / sd(pls_vip_score_diff[k, ])` divides each feature's difference vector by its own sample standard deviation, `boots_vip_sd[k]` (recomputed from `element` with the same `n-1` estimator) is analytically always exactly `1` — so `result$error[k]` equals `qt(0.975, df = <chosen df>)` exactly, deterministically, with no mocking needed. The test uses `n_samples = 10`, `nbootstrap = 20` (chosen unequal so the two candidate degrees of freedom disagree) and asserts `result$error` equals `qt(0.975, df = 9)` for every feature. Verified against the pre-fix code that the test fails with exactly the `nbootstrap`-based value (`qt(0.975, df = 19) = 2.093` instead of the expected `qt(0.975, df = 9) = 2.262`). Full existing suite (`devtools::test()`) passes unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_