### PR TITLE
Redraw a degenerate single-class bootstrap resample instead of patching one element

### DIFF
--- a/R/nmr_data_analysis.R
+++ b/R/nmr_data_analysis.R
@@ -675,19 +675,18 @@ bp_VIP_analysis <- function(dataset,
         seq_len(nbootstrap),
         function(i, x_train, y_train, ncomp) {
             num_features <- ncol(x_train)
-            index <- sample(seq_len(nrow(x_train)), nrow(x_train), replace = TRUE)
-            x_train_boots <- x_train[index, ]
-            y_train_boots <- y_train[index]
-
-            # if y_train_boots only have one class, plsda models give error
-            if (length(unique(y_train_boots)) == 1) {
-                # Replace the first element for the first element of another class
-                for (class_idx in seq_along(y_train)) {
-                    if (y_train[class_idx] != y_train_boots[1]) {
-                        y_train_boots[1] <- y_train[class_idx]
-                        x_train_boots[1, ] <- x_train[class_idx, ]
-                        break
-                    }
+            # A bootstrap resample can happen to draw only one class (plsda
+            # models require at least two); when that happens, redraw rather
+            # than patching a single element of the offending resample, which
+            # would bias every degenerate resample towards the same fixed
+            # (first-encountered) replacement sample instead of leaving the
+            # resample an unbiased draw with replacement.
+            repeat {
+                index <- sample(seq_len(nrow(x_train)), nrow(x_train), replace = TRUE)
+                x_train_boots <- x_train[index, ]
+                y_train_boots <- y_train[index]
+                if (length(unique(y_train_boots)) > 1) {
+                    break
                 }
             }
 

--- a/tests/testthat/test-nmr-data-analysis.R
+++ b/tests/testthat/test-nmr-data-analysis.R
@@ -273,18 +273,18 @@ test_that("bp_VIP_analysis shuffles each feature's own column when building its 
 
 test_that("bp_VIP_analysis recovers from a degenerate single-class bootstrap resample", {
     # Inside the bootstrap loop of bp_VIP_analysis(), if a bootstrap
-    # resample happens to contain only one class, the code recovers by
-    # swapping in one sample of the missing class from the (unbootstrapped)
-    # original y_train. To exercise this exact code path with the real
-    # function (not a reimplementation of it), we build a deliberately
-    # imbalanced train set (1 sample of class A, 4 of class B). Bootstrap
-    # resampling with replacement from 5 elements, only one of which is
-    # class A, has a per-iteration probability of ~(4/5)^5 = 32.8% of
-    # missing the lone A sample entirely (a degenerate, single-class
-    # resample). With nbootstrap = 10 draws, the probability of the
-    # degenerate branch firing at least once is 1 - 0.672^10 ~= 98%. We pin
-    # a seed (verified across 15 candidate seeds to all succeed) and assert
-    # the call completes without error.
+    # resample happens to contain only one class, the code redraws it (a
+    # fresh sample-with-replacement) until it contains more than one class,
+    # rather than patching a single element of the offending resample. To
+    # exercise this code path with the real function (not a reimplementation
+    # of it), we build a deliberately imbalanced train set (1 sample of
+    # class A, 4 of class B). Bootstrap resampling with replacement from 5
+    # elements, only one of which is class A, has a per-iteration
+    # probability of ~(4/5)^5 = 32.8% of missing the lone A sample entirely
+    # (a degenerate, single-class resample). With nbootstrap = 10 draws, the
+    # probability of the degenerate branch firing at least once is
+    # 1 - 0.672^10 ~= 98%. We pin a seed (verified across 15 candidate seeds
+    # to all succeed) and assert the call completes without error.
     skip_if_not_installed("mixOmics")
     skip_if_not_installed("BiocParallel")
 
@@ -326,18 +326,16 @@ test_that("bp_VIP_analysis recovers from a degenerate single-class bootstrap res
     expect_true(all(c("pls_vip", "relevant_vips") %in% names(result)))
 })
 
-test_that("bp_VIP_analysis's single-class recovery loop iterates over y_train's elements", {
-    # The recovery loop must iterate over each element of y_train, not treat
-    # it as a count: y_train is a factor/character vector, and seq_len()
-    # requires a scalar, so seq_len(y_train) would error.
+test_that("bp_VIP_analysis redraws a degenerate bootstrap resample instead of patching a single element", {
+    # Patching a single element of a degenerate resample (e.g. always
+    # overwriting position 1 with the first alternate-class sample found in
+    # y_train) would bias that position towards a fixed, non-random value
+    # instead of leaving the resample an unbiased draw with replacement.
+    # Guard against that pattern reappearing.
     body_txt <- paste(deparse(body(bp_VIP_analysis)), collapse = " ")
 
-    expect_true(
-        grepl("seq_along\\(y_train\\)", body_txt),
-        info = "Expected the recovery loop to iterate with seq_along(y_train)"
-    )
     expect_false(
-        grepl("seq_len\\(y_train\\)", body_txt),
-        info = "seq_len(y_train) requires a scalar count, not a vector"
+        grepl("x_train_boots\\[1, *\\] *<-", body_txt),
+        info = "A degenerate resample must be redrawn, not fixed up by patching a single row"
     )
 })


### PR DESCRIPTION
## Summary

Inside `bp_VIP_analysis()`'s bootstrap loop (`R/nmr_data_analysis.R`), a resample drawn with replacement can happen to contain only one class, which `plsda_build()` cannot fit a model on. This PR replaces the existing recovery strategy (deterministically patching one element of the resample) with rejection sampling (redrawing the whole resample until it is valid), because the patch introduced a systematic bias into the bootstrap.

## Current behaviour, and why it is wrong

```r
index <- sample(seq_len(nrow(x_train)), nrow(x_train), replace = TRUE)
x_train_boots <- x_train[index, ]
y_train_boots <- y_train[index]

if (length(unique(y_train_boots)) == 1) {
    for (class_idx in seq_along(y_train)) {
        if (y_train[class_idx] != y_train_boots[1]) {
            y_train_boots[1] <- y_train[class_idx]
            x_train_boots[1, ] <- x_train[class_idx, ]
            break
        }
    }
}
```

When the resample is degenerate, position 1 of `x_train_boots`/`y_train_boots` is overwritten with `x_train[class_idx, ]`/`y_train[class_idx]`, where `class_idx` is *the first row of the original (unbootstrapped) training set belonging to a different class than the resample's first element* — a value that depends only on the fixed ordering of `x_train`/`y_train`, not on any random draw.

This breaks the bootstrap's core assumption that each resampled dataset is an i.i.d. sample-with-replacement from the training data:

1. Every degenerate resample (across all `nbootstrap` iterations, and across different calls with the same imbalanced training set) is "fixed" with the *exact same* replacement sample. Position 1 of a degenerate resample is not random at all — it is a constant, so its variability collapses to zero instead of reflecting genuine resampling variance.
2. That constant sample is `x_train[class_idx, ]`, the *first* minority-class row in the original ordering, not a uniformly-drawn one — the recovery mechanism has a preference for a specific sample.

Since `bp_VIP_analysis()` is precisely trying to estimate the bootstrap sampling distribution of the VIP statistic (Afanador, Tran & Buydens 2013, Eqs. 12–13), silently making a fraction of the bootstrap replicates non-random undermines the very quantity the method estimates.

## Proposed fix, and why it is correct

```r
repeat {
    index <- sample(seq_len(nrow(x_train)), nrow(x_train), replace = TRUE)
    x_train_boots <- x_train[index, ]
    y_train_boots <- y_train[index]
    if (length(unique(y_train_boots)) > 1) {
        break
    }
}
```

This is standard rejection sampling: keep drawing a fresh, unbiased sample-with-replacement until it satisfies the (mandatory) constraint of containing more than one class, instead of patching an invalid draw. Every accepted resample remains an unbiased draw with replacement from `x_train`/`y_train`, conditioned only on being non-degenerate — no element is ever forced to a fixed value. The loop is guaranteed to terminate with probability 1, since `bp_VIP_analysis()` already requires (and checks, earlier in the function) that the training set itself contains at least two classes, so the probability of drawing a degenerate resample is strictly less than 1 on every attempt.

## Testing

Updated the existing "recovers from a degenerate single-class bootstrap resample" test's description to reflect the new redraw-based recovery (the behavioral assertion — that `bp_VIP_analysis()` completes without error on a deliberately class-imbalanced training set — is unchanged and still passes). Replaced the now-obsolete introspection test that guarded the old `for (class_idx in seq_along(y_train))` loop (which no longer exists) with a new one asserting the old patch pattern (`x_train_boots[1, ] <- ...`) is absent; verified this new test fails against the pre-fix code. Full existing suite (`devtools::test()`) passes, re-run 5x for flakiness given the RNG-sensitive resampling.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_