### PR TITLE
CI: install zeehio/BiocStyle@my-fixes consistently (pandoc + pkgdown fixes)

### DIFF
--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -241,8 +241,12 @@ jobs:
           ##    predefines that counter.
           ##    https://github.com/Bioconductor/BiocStyle/pull/116
           ##  - pkgdown: fixes BiocStyle/pkgdown interaction issues when
-          ##    building the pkgdown site (see the "Install pkgdown" step
-          ##    below, which re-installs this same fork defensively).
+          ##    building the pkgdown site.
+          ## Installed once, here, for every run (not just the pkgdown-deploying
+          ## devel runs): later steps' dependency installs (e.g. "Install
+          ## dependencies pass 2", which runs with upgrade = TRUE) leave an
+          ## already-installed package alone once its version satisfies the
+          ## requirement, so this doesn't need to be re-installed later.
           remotes::install_github("zeehio/BiocStyle@my-fixes", force = TRUE)
         shell: Rscript {0}
 
@@ -274,12 +278,9 @@ jobs:
       - name: Install pkgdown
         if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
-          ## zeehio/BiocStyle@my-fixes (already installed above for the pandoc
-          ## fix) also carries the pkgdown-compatibility fix, so both live on
-          ## the same branch now. Re-install defensively in case a future
-          ## dependency pass pulls in CRAN/Bioconductor BiocStyle and
-          ## overwrites it.
-          remotes::install_github("zeehio/BiocStyle@my-fixes", force = TRUE)
+          ## The pkgdown-compatibility fix for BiocStyle is already installed
+          ## by the "Install BiocStyle fork" step above (zeehio/BiocStyle@my-fixes
+          ## covers both the pandoc and pkgdown fixes now).
           remotes::install_cran("pkgdown")
         shell: Rscript {0}
 

--- a/.github/workflows/check-bioc.yml
+++ b/.github/workflows/check-bioc.yml
@@ -232,13 +232,17 @@ jobs:
         continue-on-error: true
         shell: Rscript {0}
 
-      - name: Install BiocStyle fork (pandoc >=3.8.1 uncaptioned-table counter fix)
+      - name: Install BiocStyle fork (pandoc and pkgdown compatibility fixes)
         run: |
-          ## Vignette builds fail with recent pandoc versions ("LaTeX Error: No
-          ## counter 'none' defined") because pandoc >=3.8.1 emits \LTcaptype{none}
-          ## for uncaptioned longtables, and BiocStyle's LaTeX template never
-          ## predefines that counter. Use zeehio/BiocStyle@my-fixes until the fix
-          ## lands upstream: https://github.com/Bioconductor/BiocStyle/pull/116
+          ## zeehio/BiocStyle@my-fixes carries two fixes not yet upstream:
+          ##  - pandoc >=3.8.1: vignette builds fail ("LaTeX Error: No counter
+          ##    'none' defined") because pandoc emits \LTcaptype{none} for
+          ##    uncaptioned longtables, and BiocStyle's LaTeX template never
+          ##    predefines that counter.
+          ##    https://github.com/Bioconductor/BiocStyle/pull/116
+          ##  - pkgdown: fixes BiocStyle/pkgdown interaction issues when
+          ##    building the pkgdown site (see the "Install pkgdown" step
+          ##    below, which re-installs this same fork defensively).
           remotes::install_github("zeehio/BiocStyle@my-fixes", force = TRUE)
         shell: Rscript {0}
 
@@ -270,7 +274,12 @@ jobs:
       - name: Install pkgdown
         if: github.ref == 'refs/heads/devel' && env.run_pkgdown == 'true' && runner.os == 'Linux'
         run: |
-          remotes::install_github("zeehio/BiocStyle@fix-biocstyle-with-pkgdown") # Fix BiocStyle - pkgdown interaction
+          ## zeehio/BiocStyle@my-fixes (already installed above for the pandoc
+          ## fix) also carries the pkgdown-compatibility fix, so both live on
+          ## the same branch now. Re-install defensively in case a future
+          ## dependency pass pulls in CRAN/Bioconductor BiocStyle and
+          ## overwrites it.
+          remotes::install_github("zeehio/BiocStyle@my-fixes", force = TRUE)
           remotes::install_cran("pkgdown")
         shell: Rscript {0}
 


### PR DESCRIPTION
## Summary

`zeehio/BiocStyle@my-fixes` now carries two critical fixes not yet merged upstream: the pandoc >=3.8.1 uncaptioned-table counter fix (already used in this workflow since #73) and a pkgdown-compatibility fix.

## What was wrong

`check-bioc.yml` already installed `zeehio/BiocStyle@my-fixes` early in the job (the "Install BiocStyle fork" step). But the later "Install pkgdown" step (only run for `devel` pushes) re-installed BiocStyle from a different, stale branch:

```r
remotes::install_github("zeehio/BiocStyle@fix-biocstyle-with-pkgdown")
```

That overwrote the earlier `my-fixes` install — including the pandoc fix — with a build that doesn't carry it, right before the pkgdown site build step runs later in the same job. Historically these were two separate fork branches, each fixing a different problem, hence two install steps.

## Fix

Both fixes now live on the single `my-fixes` branch, so install it **once**, unconditionally, in the early "Install BiocStyle fork" step — which also means non-`devel`/non-pkgdown CI runs (PRs, other branches) get the pandoc fix too, not just `devel` pushes.

I initially pushed a version that installed the fork a second time in the "Install pkgdown" step "defensively," reasoning that the later "Install dependencies pass 2" step (`remotes::install_local(..., upgrade = TRUE)`) might overwrite it with the official Bioconductor release. I verified that empirically instead of leaving it as a guess: I installed the fork locally, then ran the exact same `install_local(dependencies = TRUE, repos = gha_repos, upgrade = TRUE, force = TRUE)` call against this repo and checked `packageDescription("BiocStyle")` afterward — `RemoteType` stayed `"local"`, unchanged. `remotes`'s `upgrade = TRUE` logic compares version numbers, not install provenance, and since the fork's `DESCRIPTION` version already satisfies the requirement, it's left alone. So the second install wasn't defending against anything and was removed.

## Testing

Verified locally (see above) that a `remotes::install_local(upgrade = TRUE)` pass does not clobber an already-installed dependency whose version is already satisfied, regardless of source. Also validated the YAML parses correctly. No local run of the full workflow is possible (this only affects `devel`-branch and PR CI runs), but this repo's existing CI will exercise it once merged.