### PR TITLE
Fix BP-VIP k-fold randomization and plot threshold degrees of freedom

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # AlpsNMR (development version)
 
+- BP-VIP (`bp_kfold_VIP_analysis()`, `plot_vip_scores()`): the plotted
+  importance-threshold line now uses the correct degrees of freedom
+  `df = n_samples - 1` (number of training samples), matching the cut-off
+  quantile `t_{1-alpha/2,n-1}` in Afanador, Tran & Buydens (2013) and the
+  actual selection performed in `bp_VIP_analysis()`. Previously it used
+  `df = nbootstrap - 1`, so the drawn line did not correspond to the
+  threshold that selected the variables. **Breaking change**:
+  `plot_vip_scores()`'s `nbootstrap` argument has been renamed to `n_samples`.
+- `bp_kfold_VIP_analysis()`: fixed the k-fold partitioning, which assigned
+  samples to folds by a deterministic `x %% k` split while the intended
+  random shuffle was computed and then discarded (dead code). Folds are now a
+  genuine random partition of the samples.
 - `nmr_read_bruker_fid()`: fixed silent truncation of FID data to half its
   length (wrong byte-size divisor), and rewrote the function to determine
   byte order (`BYTORDA`), data type (`DTYPA`), and timing (`SW_h`, `TD`)

--- a/R/nmr_data_analysis.R
+++ b/R/nmr_data_analysis.R
@@ -915,23 +915,23 @@ bp_kfold_VIP_analysis <- function(dataset,
     }
 
     # Extract data and split for train and test
-    x_all <- dataset$peak_table
     y_all <- nmr_meta_get_column(dataset, column = y_column)
     if (length(unique(y_all)) == 1) {
         stop("Only one class in data set, at least two needed")
     }
 
-    # Random and spliting
-    x <- seq_len(length(y_all))
-    index <- sample(x, replace = FALSE)
-    x_all <- x_all[index, ]
-    y_all <- y_all[index]
-
-    # Split data for k-fold
-    k_fold_split <- split(x, x %% k)
+    # Randomly assign each sample to one of the k folds. `rep_len()` spreads the
+    # fold labels as evenly as possible and `sample()` shuffles them, so the
+    # partition is random and (nearly) balanced. The indices refer to the
+    # original dataset ordering, because bp_VIP_analysis() below reads the
+    # samples straight from `dataset` using these indices. Each fold in turn is
+    # held out as the test set, so k_fold_index[[i]] is its training set (every
+    # sample not in fold i).
+    n_all <- length(y_all)
+    fold_of_sample <- sample(rep_len(seq_len(k), n_all))
     k_fold_index <- list()
     for (i in seq_len(k)) {
-        k_fold_index[[i]] <- seq_len(length(y_all))[-k_fold_split[[i]]]
+        k_fold_index[[i]] <- which(fold_of_sample != i)
     }
 
     # bp_VIP_analysis is already parallellized.
@@ -961,6 +961,9 @@ bp_kfold_VIP_analysis <- function(dataset,
     ordered_means <- colSums(ordered_means) / k
     vip_means <- ordered_means[order(ordered_means, decreasing = TRUE)]
     error <- results[[1]]$error
+    # `error` (and hence the importance threshold line below) is taken from the
+    # first fold, so the cut-off must use that fold's training-sample count.
+    n_samples_fold1 <- length(k_fold_index[[1]])
 
     # Selection based on the means (deprecated, now ussing intersection of the vips)
     # important_vips <- vip_means[vip_means-2*error > 0]
@@ -998,7 +1001,7 @@ bp_kfold_VIP_analysis <- function(dataset,
             shape = 21,
             fill = "white"
         ) +
-        ggplot2::geom_hline(yintercept = qt(0.975, df = nbootstrap - 1)) +
+        ggplot2::geom_hline(yintercept = qt(0.975, df = n_samples_fold1 - 1)) +
         ggplot2::ggtitle("BP-VIP") +
         ggplot2::labs(x = "Variables", y = "Scores") +
         ggplot2::theme_bw()
@@ -1020,7 +1023,10 @@ bp_kfold_VIP_analysis <- function(dataset,
 #'
 #' @param vip_means vips means values of bootstraps
 #' @param error error tolerated, calculated in the bootstrap
-#' @param nbootstrap number of bootstraps realiced
+#' @param n_samples number of training samples the bootstrap models were fit on.
+#'    It sets the importance threshold line at `qt(0.975, df = n_samples - 1)`,
+#'    following Afanador, Tran & Buydens (2013), where the cut-off quantile
+#'    `t_{1-alpha/2,n-1}` uses n = number of samples (not the number of bootstraps).
 #' @param plot A boolean that indicate if results are plotted or not
 #'
 #' @return A plot of the results or a ggplot object
@@ -1070,9 +1076,9 @@ bp_kfold_VIP_analysis <- function(dataset,
 #'
 #' # plot_vip_scores(bp_results$kfold_results[[1]]$vip_means,
 #' #                bp_results$kfold_results[[1]]$error[1],
-#' #                nbootstrap = 10)
+#' #                n_samples = length(bp_results$kfold_index[[1]]))
 #'
-plot_vip_scores <- function(vip_means, error, nbootstrap, plot = TRUE) {
+plot_vip_scores <- function(vip_means, error, n_samples, plot = TRUE) {
 
     # Plot of the scores
     x <- seq_len(length(vip_means))
@@ -1091,7 +1097,7 @@ plot_vip_scores <- function(vip_means, error, nbootstrap, plot = TRUE) {
             shape = 21,
             fill = "white"
         ) +
-        ggplot2::geom_hline(yintercept = qt(0.975, df = nbootstrap - 1)) +
+        ggplot2::geom_hline(yintercept = qt(0.975, df = n_samples - 1)) +
         ggplot2::ggtitle("BP-VIP") +
         ggplot2::labs(x = "Variables", y = "Scores") +
         ggplot2::theme_bw()

--- a/man/plot_vip_scores.Rd
+++ b/man/plot_vip_scores.Rd
@@ -4,14 +4,17 @@
 \alias{plot_vip_scores}
 \title{Plot vip scores of bootstrap}
 \usage{
-plot_vip_scores(vip_means, error, nbootstrap, plot = TRUE)
+plot_vip_scores(vip_means, error, n_samples, plot = TRUE)
 }
 \arguments{
 \item{vip_means}{vips means values of bootstraps}
 
 \item{error}{error tolerated, calculated in the bootstrap}
 
-\item{nbootstrap}{number of bootstraps realiced}
+\item{n_samples}{number of training samples the bootstrap models were fit on.
+It sets the importance threshold line at \code{qt(0.975, df = n_samples - 1)},
+following Afanador, Tran & Buydens (2013), where the cut-off quantile
+\code{t_{1-alpha/2,n-1}} uses n = number of samples (not the number of bootstraps).}
 
 \item{plot}{A boolean that indicate if results are plotted or not}
 }
@@ -66,6 +69,6 @@ peak_table <- new_nmr_dataset_peak_table(
 
 # plot_vip_scores(bp_results$kfold_results[[1]]$vip_means,
 #                bp_results$kfold_results[[1]]$error[1],
-#                nbootstrap = 10)
+#                n_samples = length(bp_results$kfold_index[[1]]))
 
 }

--- a/tests/testthat/test-nmr-data-analysis.R
+++ b/tests/testthat/test-nmr-data-analysis.R
@@ -466,3 +466,49 @@ test_that("bp_VIP_analysis redraws a degenerate bootstrap resample instead of pa
         info = "A degenerate resample must be redrawn, not fixed up by patching a single row"
     )
 })
+
+test_that("plot_vip_scores draws the importance threshold at df = n_samples - 1", {
+    # Afanador, Tran & Buydens (2013) place the "Important" cut-off at the
+    # quantile t_{1-alpha/2,n-1}, where n is the number of training samples the
+    # models were fit on -- not the number of bootstrap datasets. The threshold
+    # line must therefore use df = n_samples - 1.
+    skip_if_not_installed("ggplot2")
+
+    vip_means <- c(V1 = 3, V2 = 1, V3 = 0.2)
+    error <- 2
+    n_samples <- 12L
+
+    p <- plot_vip_scores(vip_means, error, n_samples = n_samples, plot = FALSE)
+
+    # Extract the y-intercept of the horizontal threshold line from the ggplot
+    # (geom_hline stores its yintercept in that layer's data frame):
+    hline_y <- NULL
+    for (ly in p$layers) {
+        d <- ly$data
+        if (is.data.frame(d) && "yintercept" %in% names(d)) {
+            hline_y <- d$yintercept
+        }
+    }
+    expect_false(is.null(hline_y))
+    expect_equal(hline_y, qt(0.975, df = n_samples - 1))
+    # The old (wrong) API took an `nbootstrap` argument used for this df:
+    expect_false("nbootstrap" %in% names(formals(plot_vip_scores)))
+    expect_true("n_samples" %in% names(formals(plot_vip_scores)))
+})
+
+test_that("bp_kfold_VIP_analysis assigns folds at random, not by a fixed modulo split", {
+    # The previous implementation shuffled a local copy of the data but then
+    # built the folds with split(x, x %% k) over the *unshuffled* index vector,
+    # so the partition was a deterministic modulo split and the shuffle was dead
+    # code. Folds must instead be a genuine random partition of the samples.
+    body_txt <- paste(deparse(body(bp_kfold_VIP_analysis)), collapse = " ")
+
+    expect_false(
+        grepl("%%", body_txt, fixed = TRUE),
+        info = "Folds must be a random partition, not a deterministic x %% k modulo split"
+    )
+    expect_true(
+        grepl("rep_len", body_txt, fixed = TRUE),
+        info = "Random fold assignment is expected to be built from sample(rep_len(...))"
+    )
+})


### PR DESCRIPTION
## Summary

Fixes two concrete issues in the BP-VIP implementation (`R/nmr_data_analysis.R`), found while comparing the code against Afanador, Tran & Buydens, *Anal. Chim. Acta* 768 (2013) 49–56 ("Use of the bootstrap and permutation methods for a more robust variable importance in the projection metric for PLS regression").

### 1. Plot importance-threshold used the wrong degrees of freedom
`bp_kfold_VIP_analysis()` and `plot_vip_scores()` drew the "Important" cut-off line at `qt(0.975, df = nbootstrap - 1)`. The paper's cut-off quantile is `t_{1-α/2,n-1}` where **n is the number of training samples** — which is exactly what the actual selection in `bp_VIP_analysis()` uses (`df = n_samples - 1`). As a result, the drawn line did not correspond to the threshold that selected the variables.

- Both plots now use `df = n_samples - 1`. In the k-fold plot the count is taken from the first fold's training set (`length(k_fold_index[[1]])`), consistent with the error bars, which also come from the first fold.
- **Breaking change**: `plot_vip_scores()`'s `nbootstrap` argument is renamed to `n_samples` (it was only ever used to compute this df).

### 2. Dead k-fold randomization
`bp_kfold_VIP_analysis()` shuffled a local copy of the data but then built folds with `split(x, x %% k)` over the **unshuffled** index vector, so the partition was a deterministic modulo split and the shuffle was dead code (`bp_VIP_analysis()` re-reads the original dataset anyway). Folds are now a genuine random partition via `sample(rep_len(seq_len(k), n))`.

The `nbootstrap - 1` denominator in the bootstrap standard deviation (Eqs. 12–13, B−1) is unchanged — that one is correct.

## Testing

R 4.6.1 + mixOmics 6.36.0 / BiocParallel; `tests/testthat/test-nmr-data-analysis.R`: **12 tests, 36 assertions, 0 failures**. Added two regression tests:
- `plot_vip_scores` draws the threshold at `df = n_samples - 1` (and the API takes `n_samples`, not `nbootstrap`).
- `bp_kfold_VIP_analysis` assigns folds at random, not by a fixed modulo split (source-level guard, matching the file's existing guard-test style).

## Changes
- `R/nmr_data_analysis.R` — the two fixes above.
- `man/plot_vip_scores.Rd` — regenerated for the renamed argument.
- `tests/testthat/test-nmr-data-analysis.R` — two new regression tests.
- `NEWS.md` — changelog entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPrhgshpY7wj3cFT97SXRR)_