### PR TITLE
Add test coverage for R/file_lister.R

### DIFF
--- a/tests/testthat/test-file_lister.R
+++ b/tests/testthat/test-file_lister.R
@@ -1,0 +1,30 @@
+test_that("file_lister lists files matching the glob, as plain character paths", {
+    tmp_dir <- withr::local_tempdir()
+    file.create(file.path(tmp_dir, c("Sample10.zip", "Sample20.zip", "notes.txt")))
+
+    result <- file_lister(tmp_dir, "*.zip")
+
+    expect_type(result, "character")
+    expect_setequal(
+        result,
+        file.path(tmp_dir, c("Sample10.zip", "Sample20.zip"))
+    )
+})
+
+test_that("file_lister returns an empty character vector when nothing matches", {
+    tmp_dir <- withr::local_tempdir()
+    file.create(file.path(tmp_dir, "notes.txt"))
+
+    result <- file_lister(tmp_dir, "*.zip")
+
+    expect_equal(result, character(0))
+})
+
+test_that("file_lister works on the package's demo dataset directory", {
+    dir_to_demo_dataset <- system.file("dataset-demo", package = "AlpsNMR")
+
+    result <- file_lister(dir_to_demo_dataset, "*.zip")
+
+    expect_length(result, 3)
+    expect_true(all(grepl("\\.zip$", result)))
+})


### PR DESCRIPTION
## Summary

`R/file_lister.R` (the `file_lister()` function, a thin wrapper around `fs::dir_ls()`) had 0% coverage per `covr::package_coverage()`. Adds `tests/testthat/test-file_lister.R` covering: glob matching against a controlled temp directory, the empty-match case, and the package's own demo dataset directory (matching the function's roxygen `@examples`).

## Testing

`devtools::test()` — full suite passes. `covr::file_coverage()` on this file alone: 100%.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_