### PR TITLE
Add test coverage for R/nmr_data.R

### DIFF
--- a/tests/testthat/test-nmr_data.R
+++ b/tests/testthat/test-nmr_data.R
@@ -7,3 +7,83 @@ test_that("new_nmr_dataset_1D", {
     dataset <- nmr_data(ds)
     expect_true(is.matrix(dataset))
 })
+
+test_that("nmr_data.nmr_dataset_1D names the rows/columns from the sample names and ppm axis", {
+    ds <- new_nmr_dataset_1D(
+        ppm_axis = c(1, 2, 3),
+        data_1r = matrix(c(1, 2, 1, 4, 5, 6), nrow = 2, byrow = TRUE),
+        metadata = list(external = data.frame(NMRExperiment = c("10", "20")))
+    )
+    d <- nmr_data(ds)
+    expect_equal(rownames(d), c("10", "20"))
+    expect_equal(colnames(d), c("1", "2", "3"))
+    expect_equal(unname(d), matrix(c(1, 2, 1, 4, 5, 6), nrow = 2, byrow = TRUE))
+})
+
+test_that("nmr_data.nmr_dataset_1D reads a different data_ field via the what argument", {
+    ds <- new_nmr_dataset_1D(
+        ppm_axis = c(1, 2, 3),
+        data_1r = matrix(c(1, 2, 1), nrow = 1),
+        metadata = list(external = data.frame(NMRExperiment = "10"))
+    )
+    ds$data_1i <- matrix(c(5, 6, 7), nrow = 1)
+    d <- nmr_data(ds, what = "data_1i")
+    expect_equal(unname(d), matrix(c(5, 6, 7), nrow = 1))
+})
+
+test_that("nmr_data.nmr_dataset_peak_table names the rows from the sample names", {
+    peak_table <- matrix(1:6, nrow = 2, dimnames = list(NULL, c("P1", "P2", "P3")))
+    metadata <- list(external = data.frame(NMRExperiment = letters[1:2]))
+    dataset_peak_table <- new_nmr_dataset_peak_table(peak_table, metadata)
+
+    pt <- nmr_data(dataset_peak_table)
+
+    expect_equal(rownames(pt), c("a", "b"))
+    expect_equal(colnames(pt), c("P1", "P2", "P3"))
+    expect_equal(unname(pt), unname(peak_table))
+})
+
+test_that("nmr_data has no method for unsupported classes", {
+    expect_error(nmr_data(list()), "no applicable method")
+})
+
+test_that("nmr_data<-.nmr_dataset_1D replaces data_1r and strips any row/col names", {
+    ds <- new_nmr_dataset_1D(
+        ppm_axis = c(1, 2, 3),
+        data_1r = matrix(c(1, 2, 1), nrow = 1),
+        metadata = list(external = data.frame(NMRExperiment = "10"))
+    )
+    replacement <- matrix(c(9, 8, 7), nrow = 1, dimnames = list("10", c("a", "b", "c")))
+
+    nmr_data(ds) <- replacement
+
+    expect_equal(unname(ds$data_1r), matrix(c(9, 8, 7), nrow = 1))
+    expect_null(rownames(ds$data_1r))
+    expect_null(colnames(ds$data_1r))
+})
+
+test_that("nmr_data<-.nmr_dataset_1D requires the replacement to have one row per sample", {
+    ds <- new_nmr_dataset_1D(
+        ppm_axis = c(1, 2, 3),
+        data_1r = matrix(c(1, 2, 1), nrow = 1),
+        metadata = list(external = data.frame(NMRExperiment = "10"))
+    )
+    expect_error(
+        nmr_data(ds) <- matrix(1:6, nrow = 2),
+        "nrow"
+    )
+})
+
+test_that("nmr_data<-.nmr_dataset_1D removes the field entirely when value is NULL", {
+    ds <- new_nmr_dataset_1D(
+        ppm_axis = c(1, 2, 3),
+        data_1r = matrix(c(1, 2, 1), nrow = 1),
+        metadata = list(external = data.frame(NMRExperiment = "10"))
+    )
+    nmr_data(ds) <- NULL
+    expect_false("data_1r" %in% names(unclass(ds)))
+})
+
+test_that("nmr_data<- has no method for unsupported classes", {
+    expect_error(`nmr_data<-`(list(), value = 1), "no applicable method")
+})


### PR DESCRIPTION
## Summary

`R/nmr_data.R` had 53.33% coverage. Extends `tests/testthat/test-nmr_data.R` (which only had one basic test) with:

- `nmr_data.nmr_dataset_1D`: rownames/colnames set from the sample names and ppm axis, and the `what` argument reading a `data_` field other than `data_1r`.
- `nmr_data.nmr_dataset_peak_table`: rownames set from the sample names.
- `nmr_data()`: the "no applicable method" dispatch error for unsupported classes.
- `nmr_data<-.nmr_dataset_1D`: replacing `data_1r` and stripping any row/col names off the replacement value, the `nrow` must match `num_samples` check, and the `NULL`-value case (removes the field entirely — standard R list-assignment semantics).
- `nmr_data<-()`: the "no applicable method" dispatch error for unsupported classes.

## Testing

`devtools::test()` — full suite passes (14 new tests, all green). No bugs found.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_