### PR TITLE
Require baselineThresh or range_without_peaks in nmr_detect_peaks() (fixes #66)

### DIFF
--- a/R/nmr_detect_peaks_align.R
+++ b/R/nmr_detect_peaks_align.R
@@ -93,10 +93,12 @@ NULL
 #' @param baselineThresh All peaks with intensities below the thresholds are excluded. Either:
 #'   - A numeric vector of length the number of samples. Each number is a threshold for that sample
 #'   - A single number. All samples use this number as baseline threshold.
-#'   - `NULL`. If that's the case, a default function is used ([nmr_baseline_threshold()]), which assumes 
-#'     that there is no signal in the region 9.5-10 ppm. 
+#'   - `NULL`. If that's the case, a default function is used ([nmr_baseline_threshold()]) with the
+#'     given `range_without_peaks`. There is no ppm range guaranteed to be free of peaks for every
+#'     sample type, so `range_without_peaks` must be given when `baselineThresh` is `NULL`.
 #' @inheritParams speaq::detectSpecPeaks
-#' @param range_without_peaks A numeric vector of length two with a region without peaks, only used when `baselineThresh = NULL`
+#' @param range_without_peaks A numeric vector of length two with a region without peaks.
+#'     Required when `baselineThresh = NULL`, ignored otherwise.
 #' @param fit_lorentzians If `TRUE`, fit a lorentzian to each detected peak, to infer its inflection points. For now disabled for backwards compatibility.
 #' @param verbose Logical (`TRUE` or `FALSE`). Show informational messages, such as the estimated baseline
 #' @return A data frame with the NMRExperiment, the sample index, the position
@@ -108,10 +110,19 @@ nmr_detect_peaks <- function(nmr_dataset,
     scales = seq(1, 16, 2),
     baselineThresh = NULL,
     SNR.Th = 3,
-    range_without_peaks = c(9.5, 10),
+    range_without_peaks = NULL,
     fit_lorentzians = FALSE,
     verbose = FALSE) {
     nmr_dataset <- validate_nmr_dataset_1D(nmr_dataset)
+    if (is.null(baselineThresh) && is.null(range_without_peaks)) {
+        rlang::abort(
+            message = c(
+                "Either baselineThresh or range_without_peaks must be given",
+                "i" = "There is no ppm range guaranteed to be free of peaks for every sample type.",
+                "i" = "Pass range_without_peaks (a two-value ppm range known to be free of peaks for your samples) to estimate baselineThresh automatically, or pass baselineThresh directly."
+            )
+        )
+    }
 
     # Convert ppm to number of data points
     ppm_resolution <- stats::median(diff(nmr_dataset$axis))

--- a/man/Pipelines.Rd
+++ b/man/Pipelines.Rd
@@ -106,8 +106,9 @@ for peaks.}
 \itemize{
 \item A numeric vector of length the number of samples. Each number is a threshold for that sample
 \item A single number. All samples use this number as baseline threshold.
-\item \code{NULL}. If that's the case, a default function is used (\code{\link[=nmr_baseline_threshold]{nmr_baseline_threshold()}}), which assumes
-that there is no signal in the region 9.5-10 ppm.
+\item \code{NULL}. If that's the case, a default function is used (\code{\link[=nmr_baseline_threshold]{nmr_baseline_threshold()}}) with the
+given \code{range_without_peaks}. There is no ppm range guaranteed to be free of peaks for every
+sample type, so \code{range_without_peaks} must be given when \code{baselineThresh} is \code{NULL}.
 }}
 
 \item{SNR.Th}{The parameter of peakDetectionCWT function of MassSpecWavelet package, look it up in the original function. If you set -1, the function will itself re-compute this value.}

--- a/man/nmr_detect_peaks.Rd
+++ b/man/nmr_detect_peaks.Rd
@@ -10,7 +10,7 @@ nmr_detect_peaks(
   scales = seq(1, 16, 2),
   baselineThresh = NULL,
   SNR.Th = 3,
-  range_without_peaks = c(9.5, 10),
+  range_without_peaks = NULL,
   fit_lorentzians = FALSE,
   verbose = FALSE
 )
@@ -27,13 +27,15 @@ for peaks.}
 \itemize{
 \item A numeric vector of length the number of samples. Each number is a threshold for that sample
 \item A single number. All samples use this number as baseline threshold.
-\item \code{NULL}. If that's the case, a default function is used (\code{\link[=nmr_baseline_threshold]{nmr_baseline_threshold()}}), which assumes
-that there is no signal in the region 9.5-10 ppm.
+\item \code{NULL}. If that's the case, a default function is used (\code{\link[=nmr_baseline_threshold]{nmr_baseline_threshold()}}) with the
+given \code{range_without_peaks}. There is no ppm range guaranteed to be free of peaks for every
+sample type, so \code{range_without_peaks} must be given when \code{baselineThresh} is \code{NULL}.
 }}
 
 \item{SNR.Th}{The parameter of peakDetectionCWT function of MassSpecWavelet package, look it up in the original function. If you set -1, the function will itself re-compute this value.}
 
-\item{range_without_peaks}{A numeric vector of length two with a region without peaks, only used when \code{baselineThresh = NULL}}
+\item{range_without_peaks}{A numeric vector of length two with a region without peaks.
+Required when \code{baselineThresh = NULL}, ignored otherwise.}
 
 \item{fit_lorentzians}{If \code{TRUE}, fit a lorentzian to each detected peak, to infer its inflection points. For now disabled for backwards compatibility.}
 

--- a/man/nmr_detect_peaks_tune_snr.Rd
+++ b/man/nmr_detect_peaks_tune_snr.Rd
@@ -28,10 +28,12 @@ for peaks.}
 \itemize{
 \item A numeric vector of length the number of samples. Each number is a threshold for that sample
 \item A single number. All samples use this number as baseline threshold.
-\item \code{NULL}. If that's the case, a default function is used (\code{\link[=nmr_baseline_threshold]{nmr_baseline_threshold()}}), which assumes
-that there is no signal in the region 9.5-10 ppm.
+\item \code{NULL}. If that's the case, a default function is used (\code{\link[=nmr_baseline_threshold]{nmr_baseline_threshold()}}) with the
+given \code{range_without_peaks}. There is no ppm range guaranteed to be free of peaks for every
+sample type, so \code{range_without_peaks} must be given when \code{baselineThresh} is \code{NULL}.
 }}
-    \item{\code{range_without_peaks}}{A numeric vector of length two with a region without peaks, only used when \code{baselineThresh = NULL}}
+    \item{\code{range_without_peaks}}{A numeric vector of length two with a region without peaks.
+Required when \code{baselineThresh = NULL}, ignored otherwise.}
     \item{\code{fit_lorentzians}}{If \code{TRUE}, fit a lorentzian to each detected peak, to infer its inflection points. For now disabled for backwards compatibility.}
     \item{\code{verbose}}{Logical (\code{TRUE} or \code{FALSE}). Show informational messages, such as the estimated baseline}
     \item{\code{scales}}{The parameter of peakDetectionCWT function of MassSpecWavelet package, look it up in the original function.}

--- a/tests/testthat/test-nmr_detect_peaks_align.R
+++ b/tests/testthat/test-nmr_detect_peaks_align.R
@@ -10,6 +10,21 @@ make_dataset <- function(with_baseline = FALSE) {
     ds
 }
 
+## nmr_detect_peaks ------------------------------------------------------------
+
+test_that("nmr_detect_peaks requires either baselineThresh or range_without_peaks", {
+    # Regression test for https://github.com/sipss/AlpsNMR/issues/66:
+    # nmr_detect_peaks() used to silently default range_without_peaks to
+    # c(9.5, 10), which errors deep inside nmr_baseline_threshold() with a
+    # confusing message when the dataset's axis doesn't reach that range.
+    # It must instead fail early with a clear, actionable message.
+    ds <- make_dataset()
+    expect_error(
+        nmr_detect_peaks(ds),
+        "Either baselineThresh or range_without_peaks must be given"
+    )
+})
+
 ## peakList_to_dataframe / peak_data_to_peakList (round trip) -----------------
 
 test_that("peakList_to_dataframe builds one row per peak with ppm/pos/intensity columns", {

--- a/vignettes/Vig01b-introduction-to-alpsnmr-old-api.Rmd
+++ b/vignettes/Vig01b-introduction-to-alpsnmr-old-api.Rmd
@@ -306,7 +306,8 @@ a dynamic baseline threshold level.
 peak_table <- nmr_detect_peaks(dataset,
                                nDivRange_ppm = 0.1,
                                scales = seq(1, 16, 2),
-                               baselineThresh = NULL, SNR.Th = 3)
+                               baselineThresh = NULL, SNR.Th = 3,
+                               range_without_peaks = c(9.5, 10))
 NMRExp_ref <- nmr_align_find_ref(dataset, peak_table)
 message("Your reference is NMRExperiment ", NMRExp_ref)
 nmr_detect_peaks_plot(dataset, peak_table, NMRExperiment = "20", chemshift_range = c(3.5,3.8))


### PR DESCRIPTION
## Summary

Fixes #66. `nmr_detect_peaks()` had its own hardcoded `range_without_peaks = c(9.5, 10)` default, separate from (and unaffected by) the similar fix already made to `nmr_baseline_threshold()` itself in #88. When `baselineThresh = NULL` and the dataset's axis didn't reach 9.5-10 ppm, this surfaced as a confusing error several calls deep, with no indication that `range_without_peaks` was the thing to fix:

```
Can't estimate a baseline threshold reliably
i The selected range_without_peaks [9.5,10] ppm contains 0 points.
i Either change the interpolation axis limits or choose a different range here
```

`range_without_peaks` now defaults to `NULL` like `baselineThresh` does, and `nmr_detect_peaks()` aborts immediately with a clear, actionable message if both are `NULL`:

```
Either baselineThresh or range_without_peaks must be given
i There is no ppm range guaranteed to be free of peaks for every sample type.
i Pass range_without_peaks (...) to estimate baselineThresh automatically, or pass baselineThresh directly.
```

Updates the one caller relying on the implicit default (`Vig01b-introduction-to-alpsnmr-old-api.Rmd` — its dataset does extend to 10 ppm, so `range_without_peaks = c(9.5, 10)` is now passed explicitly there).

## Testing

Added a regression test, verified (via `git stash`) to reproduce the original confusing error against the pre-fix code, and to fail clearly and immediately against the fix. `devtools::test()` — full suite passes (697 tests, all green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_