### PR TITLE
tidy.nmr_dataset_1D(): warn or error on unknown NMRExperiment values (fixes #69)

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -346,6 +346,29 @@ tidy.nmr_dataset_1D <-
             sample_idx <- seq_along(NMRExperiment)
         } else {
             sample_idx <- match(NMRExperiment, names(x))
+            is_unknown <- is.na(sample_idx)
+            if (any(is_unknown)) {
+                valid_examples <- paste(utils::head(names(x), 2), collapse = ", ")
+                unknown_values <- paste(NMRExperiment[is_unknown], collapse = ", ")
+                if (all(is_unknown)) {
+                    rlang::abort(
+                        message = c(
+                            "None of the given NMRExperiment values were found in the dataset",
+                            "x" = glue::glue("Not found: {unknown_values}"),
+                            "i" = glue::glue("Some valid NMRExperiment values are: {valid_examples}")
+                        )
+                    )
+                }
+                cli::cli_warn(
+                    message = c(
+                        "!" = "Some NMRExperiment values were not found in the dataset and will be excluded",
+                        "x" = "Not found: {unknown_values}",
+                        "i" = "Some valid NMRExperiment values are: {valid_examples}"
+                    )
+                )
+                NMRExperiment <- NMRExperiment[!is_unknown]
+                sample_idx <- sample_idx[!is_unknown]
+            }
         }
         chemshift_in_range <- decimate_axis(
             xaxis = x[[axis_name]],

--- a/tests/testthat/test-plots.R
+++ b/tests/testthat/test-plots.R
@@ -135,6 +135,41 @@ test_that("tidy.nmr_dataset_1D returns a long data frame with NMRExperiment/chem
     expect_true(all(df$chemshift >= 0.2 & df$chemshift <= 0.6))
 })
 
+test_that("tidy.nmr_dataset_1D warns and excludes unknown NMRExperiment values when some are valid", {
+    # Regression test for https://github.com/sipss/AlpsNMR/issues/69: an
+    # unknown NMRExperiment used to silently produce NA-filled rows labelled
+    # with the wrong (nonexistent) name instead of warning and dropping them.
+    dataset <- make_large_nmr_dataset_1D(3)
+
+    expect_warning(
+        df <- tidy(dataset, NMRExperiment = c(names(dataset)[1], "does-not-exist")),
+        "does-not-exist"
+    )
+
+    expect_equal(unique(df$NMRExperiment), names(dataset)[1])
+    expect_false(anyNA(df$intensity))
+})
+
+test_that("tidy.nmr_dataset_1D errors when every given NMRExperiment value is unknown", {
+    dataset <- make_large_nmr_dataset_1D(3)
+
+    expect_error(
+        tidy(dataset, NMRExperiment = c("does-not-exist-1", "does-not-exist-2")),
+        "None of the given NMRExperiment values"
+    )
+})
+
+test_that("tidy.nmr_dataset_1D's error/warning suggest some valid NMRExperiment values", {
+    dataset <- make_large_nmr_dataset_1D(3)
+    valid_examples <- paste(utils::head(names(dataset), 2), collapse = ", ")
+
+    expect_error(
+        tidy(dataset, NMRExperiment = "does-not-exist"),
+        valid_examples,
+        fixed = TRUE
+    )
+})
+
 ## plot_interactive / plot_webgl ----------------------------------------------
 
 test_that("plot_interactive writes an html file and a lib/ folder, and aborts on a pre-existing lib/ unless told to overwrite", {


### PR DESCRIPTION
## Summary

Fixes #69. Passing an `NMRExperiment` value that doesn't exist in the dataset used to silently produce rows labelled with the wrong (nonexistent) name and `NA` intensity values — `match()`'s `NA` fallback flowed straight into matrix subsetting with no validation.

Now, matching the behavior requested in the issue:

- If **some** (not all) of the given `NMRExperiment` values are unknown, warn and proceed with only the valid ones.
- If **none** of them are found, abort.

Both messages list which values weren't found and a couple of valid `NMRExperiment` values from the dataset (`head(names(x), 2)`), so the user is guided to fix the problem.

This transitively fixes the same silent-`NA` behavior in `nmr_baseline_threshold_plot()` too, since it forwards a user-supplied `NMRExperiment` straight through to `tidy()`.

## Testing

Added regression tests, verified (via `git stash`) to fail against the pre-fix code with the exact symptoms described in the issue (missing warning/error, wrong-name rows, `NA` intensities). `devtools::test()` — full suite passes unchanged (701 tests, all green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_