### PR TITLE
Standardize on cli for user-facing messages, errors and warnings

### DIFF
--- a/R/area_estimation.R
+++ b/R/area_estimation.R
@@ -74,7 +74,7 @@ refine_lorentzian_fit_with_nls <- function(data_to_fit, start, method) {
     } else if (method == "2nd_derivative") {
         formula <- y ~ -2 * A * gamma / pi * (gamma^2 - 3 * (x - x0)^2) / (gamma^2 + (x - x0)^2)^3
     } else {
-        rlang::abort("Unknown method")
+        cli::cli_abort("Unknown method")
     }
 
     tryCatch(
@@ -195,7 +195,7 @@ peaklist_fit_lorentzians <- function(peak_data,
                     y_basel <- as.numeric(nmr_dataset$data_1r_baseline[sindex, ])
                 } else {
                     if (!has_warned_baseline) {
-                        rlang::warn(
+                        cli::cli_warn(
                             c(
                                 "Estimating the baseline using ALS with lambda 9 and p = 0.05...",
                                 "i" = "Use nmr_baseline_estimation before calling this function to customize"
@@ -248,7 +248,7 @@ peaklist_fit_lorentzians <- function(peak_data,
             # Estimate A based on the amplitude of the signal without baseline
             estimated_A <- y_nobasel[posi] * pi * gamma
         } else {
-            rlang::abort(sprintf("amplitude_method '%s'unknown", amplitude_method))
+            cli::cli_abort(sprintf("amplitude_method '%s'unknown", amplitude_method))
         }
         if (identical(refine_peak_model, "peak")) {
             # Further fitting with nls:
@@ -293,7 +293,7 @@ peaklist_fit_lorentzians <- function(peak_data,
                 all_errors$error_msg <- c(all_errors$error_msg, paste(new_params[["error_msgs"]], collapse = "\n"))
             }
         } else if (!identical(refine_peak_model, "none")) {
-            rlang::abort("Unknown refine_peak_model")
+            cli::cli_abort("Unknown refine_peak_model")
         }
         # And then get the whole lorentzian:
         y_fitted <- lorentzian(
@@ -449,7 +449,7 @@ peaklist_accept_peaks <- function(peak_data, nmr_dataset, nrmse_max = Inf, area_
         peak_data$accepted <- NULL
     }
     if (verbose) {
-        rlang::inform(message = report)
+        cli::cli_inform(message = report)
     }
     peak_data
 }

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -77,7 +77,7 @@ download_MTBLS242 <- function(
     annotations_orig_destfile <- file.path(dest_dir, "s_mtbls242.txt")
     dst_rootdir <- file.path(dest_dir, "samples")
     if (!file.exists(annotations_orig_destfile) || force) {
-        rlang::inform(c("i" = "Downloading sample annotations..."))
+        cli::cli_inform(c("i" = "Downloading sample annotations..."))
         curl_download_retry(url = meta_url, destfile = annotations_orig_destfile)
     }
     if (!file.exists(annotations_destfile) || force) {
@@ -147,7 +147,7 @@ download_MTBLS242 <- function(
         }
         utils::write.table(sample_annot, file = annotations_destfile, sep = "\t", row.names = FALSE)
     } else {
-        rlang::inform(c("i" = glue("Annotations were previously saved. Loading {annotations_destfile}")))
+        cli::cli_inform(c("i" = glue("Annotations were previously saved. Loading {annotations_destfile}")))
         sample_annot <- utils::read.csv(annotations_destfile, header = TRUE, sep = "\t")
     }
     dir.create(dst_rootdir, recursive = TRUE, showWarnings = FALSE)
@@ -161,7 +161,7 @@ download_MTBLS242 <- function(
             intermediate_dst_file <- file.path(dst_rootdir, paste0(filename, "intermediate.zip"))
             if (file.exists(final_dst_file) && !force) {
                 if (!report_skipped_downloads) {
-                    rlang::inform(c("i" = "Skipping re-download of previously downloaded samples."))
+                    cli::cli_inform(c("i" = "Skipping re-download of previously downloaded samples."))
                     report_skipped_downloads <<- TRUE
                 }
                 return()

--- a/R/import_jdx.R
+++ b/R/import_jdx.R
@@ -196,7 +196,7 @@ process_block <- function(lines, metadata_only = FALSE) {
                 next
             }
             # Unknown data format:
-            rlang::abort(c(
+            cli::cli_abort(c(
                 "The format of this data field is not implemented",
                 "i" = sprintf("Line: %d", i),
                 "i" = sprintf("Content: %s", line)
@@ -236,7 +236,7 @@ process_block <- function(lines, metadata_only = FALSE) {
         # Convert x axis from frequency to chemshift
         if (!is.null(block[["XUNITS"]]) && tolower(block[["XUNITS"]]) == "hz") {
             if (is.null(block[[".OBSERVE FREQUENCY"]])) {
-                rlang::abort(".OBSERVE FREQUENCY is missing from the JDX file but XUNITS is 'Hz'")
+                cli::cli_abort(".OBSERVE FREQUENCY is missing from the JDX file but XUNITS is 'Hz'")
             }
             block[[data_field]][["x"]] <-
                 block[[data_field]][["x"]] / block[[".OBSERVE FREQUENCY"]]

--- a/R/nmr_baseline_threshold.R
+++ b/R/nmr_baseline_threshold.R
@@ -39,7 +39,7 @@ nmr_baseline_threshold <- function(nmr_dataset, range_without_peaks = NULL, meth
     # FIXME: Maybe a whole baseline would be better, so we can cope with slowly changing baselines better
     method <- match.arg(method)
     if (is.null(range_without_peaks)) {
-        rlang::abort(
+        cli::cli_abort(
             message = c(
                 "range_without_peaks must be given",
                 "i" = "There is no ppm range guaranteed to be free of peaks for every sample type.",
@@ -48,13 +48,13 @@ nmr_baseline_threshold <- function(nmr_dataset, range_without_peaks = NULL, meth
         )
     }
     if (length(range_without_peaks) != 2) {
-        rlang::abort("range_without_peaks must have length 2")
+        cli::cli_abort("range_without_peaks must have length 2")
     }
     r_start <- min(range_without_peaks)
     r_end <- max(range_without_peaks)
     threshold_ind <- nmr_dataset$axis >= r_start & nmr_dataset$axis < r_end
     if (sum(threshold_ind) < 10) {
-        rlang::abort(
+        cli::cli_abort(
             message = c(
                 "Can't estimate a baseline threshold reliably",
                 "i" = glue("The selected range_without_peaks [{r_start},{r_end}] ppm contains {sum(threshold_ind)} points."),
@@ -115,7 +115,7 @@ nmr_baseline_threshold <- function(nmr_dataset, range_without_peaks = NULL, meth
 #' nmr_baseline_threshold_plot(dataset_1D, bl_threshold, chemshift_range = c(9.5, 10))
 nmr_baseline_threshold_plot <- function(nmr_dataset, thresholds, NMRExperiment = "all", chemshift_range = NULL, ...) {
     if (is.null(chemshift_range)) {
-        rlang::abort(
+        cli::cli_abort(
             message = c(
                 "chemshift_range must be given",
                 "i" = "There is no ppm range guaranteed to be free of peaks for every sample type.",

--- a/R/nmr_data_analysis_cv_split.R
+++ b/R/nmr_data_analysis_cv_split.R
@@ -85,7 +85,7 @@ random_subsampling <- function(sample_idx,
                 test = test_samples
             )
             if (length(train_samples) == 0 || length(test_samples) == 0) {
-                rlang::abort(
+                cli::cli_abort(
                     message = c(
                         "Too few samples in a random subsampling split",
                         "i" = glue::glue("Train samples: {length(train_samples)}"),
@@ -107,7 +107,7 @@ random_subsampling <- function(sample_idx,
                 test = test_samples
             )
             if (length(train_samples) == 0 || length(test_samples) == 0) {
-                rlang::abort(
+                cli::cli_abort(
                     message = c(
                         "Too few samples in a random subsampling split",
                         "i" = glue::glue("Train samples: {length(train_samples)}"),
@@ -215,7 +215,7 @@ split_build_perform <- function(train_test_subset,
     x_all <- nmr_data(dataset)
     y_all <- nmr_meta_get_column(dataset, column = y_column)
     if (is.null(y_all)) {
-        rlang::abort(
+        cli::cli_abort(
             c(
                 "y_column not found",
                 "x" = sprintf('Column "%s" does not exist in the dataset', y_column)

--- a/R/nmr_dataset.R
+++ b/R/nmr_dataset.R
@@ -64,7 +64,7 @@ nmr_read_samples_dir <- function(samples_dir,
     samples_dir <- as.character(samples_dir)
     dirs_that_dont_exist <- !dir.exists(samples_dir)
     if (any(dirs_that_dont_exist)) {
-        rlang::abort(c("These directories do not exist:", samples_dir[dirs_that_dont_exist]))
+        cli::cli_abort(c("These directories do not exist:", samples_dir[dirs_that_dont_exist]))
     }
     if (format == "bruker") {
         all_samples <-
@@ -269,7 +269,7 @@ nmr_read_samples_bruker <-
                         },
                         error = function(err) {
                             msg <- conditionMessage(err)
-                            rlang::warn(
+                            cli::cli_warn(
                                 message = c(
                                     "Error loading a sample",
                                     "i" = glue::glue("The sample '{sampl}' failed to load"),
@@ -300,7 +300,7 @@ nmr_read_samples_bruker <-
 
 
         if (length(list_of_samples) == 0) {
-            rlang::abort(
+            cli::cli_abort(
                 message = c(
                     "No samples could be loaded",
                     "i" = "You can check the underlying error messages with rlang::last_error()$error_list"
@@ -406,7 +406,7 @@ nmr_read_samples_jdx <-
         # 3. Based on the filename
         if (!is.null(nn)) {
             if (anyDuplicated(nn) > 0) {
-                rlang::abort("names of samples must be unique")
+                cli::cli_abort("names of samples must be unique")
             }
             NMRExperiments <- nn
         } else if (!"NMRExperiment" %in% colnames(metadata)) {

--- a/R/nmr_dataset_1D.R
+++ b/R/nmr_dataset_1D.R
@@ -87,7 +87,7 @@ validate_nmr_dataset_1D <- function(nmr_dataset_1D) {
     )
 
     if (!"excluded_regions" %in% names(unclass(nmr_dataset_1D))) {
-        rlang::warn(
+        cli::cli_warn(
             message = c(
                 'The dataset should have a "excluded_regions" element with the excluded regions.',
                 "i" = paste0(

--- a/R/nmr_dataset_family.R
+++ b/R/nmr_dataset_family.R
@@ -121,7 +121,7 @@ names.nmr_dataset_family <- function(x) {
 #' @export
 `names<-.nmr_dataset_family` <- function(x, value) {
     if (length(value) != x$num_samples) {
-        rlang::abort(
+        cli::cli_abort(
             message = c(
                 glue("names should be vector of length {x$num_samples}, but a vector of length {length(value)} was given instead")
             )
@@ -129,7 +129,7 @@ names.nmr_dataset_family <- function(x) {
     }
     if (anyDuplicated(value) > 0) {
         (
-            rlang::abort("NMRExperiment names should not be repeated")
+            cli::cli_abort("NMRExperiment names should not be repeated")
         )
     }
     for (table_name in names(x$metadata)) {

--- a/R/nmr_detect_peaks_align.R
+++ b/R/nmr_detect_peaks_align.R
@@ -115,7 +115,7 @@ nmr_detect_peaks <- function(nmr_dataset,
     verbose = FALSE) {
     nmr_dataset <- validate_nmr_dataset_1D(nmr_dataset)
     if (is.null(baselineThresh) && is.null(range_without_peaks)) {
-        rlang::abort(
+        cli::cli_abort(
             message = c(
                 "Either baselineThresh or range_without_peaks must be given",
                 "i" = "There is no ppm range guaranteed to be free of peaks for every sample type.",
@@ -134,7 +134,7 @@ nmr_detect_peaks <- function(nmr_dataset,
         if (isTRUE(verbose)) {
             if (length(baselineThresh) > 1L) {
                 bth_minmax <- range(baselineThresh)
-                rlang::inform(
+                cli::cli_inform(
                     message = c(
                         "i" = glue::glue("Using baseline thresholds in the range [{bthmin} - {bthmax}]",
                             bthmin = bth_minmax[1], bthmax = bth_minmax[2]
@@ -142,13 +142,13 @@ nmr_detect_peaks <- function(nmr_dataset,
                     )
                 )
             } else {
-                rlang::inform(
+                cli::cli_inform(
                     message = c(
                         "i" = glue::glue("Using baselineThresh={baselineThresh}", baselineThresh = baselineThresh)
                     )
                 )
             }
-            rlang::inform(
+            cli::cli_inform(
                 message = c(
                     "i" = glue::glue(
                         "You may plot(<your-dataset>, chemshift_range=c({rmin}, {rmax})) ",
@@ -163,7 +163,7 @@ nmr_detect_peaks <- function(nmr_dataset,
     }
 
     if (!is.numeric(baselineThresh)) {
-        rlang::abort(glue::glue("The baseline threshold is not numeric: {baselineThresh}"))
+        cli::cli_abort(glue::glue("The baseline threshold is not numeric: {baselineThresh}"))
     }
     if (length(baselineThresh) == 1) {
         baselineThresh <- rep(baselineThresh, times = nmr_dataset$num_samples)

--- a/R/nmr_interpolate.R
+++ b/R/nmr_interpolate.R
@@ -57,7 +57,7 @@ nmr_interpolate_1D.nmr_dataset <- function(samples, axis = c(min = 0.2, max = 10
     verify_dimensionality(samples, valid_dimensions = 1)
 
     if (missing(axis)) {
-        rlang::inform(
+        cli::cli_inform(
             message = c(
                 "Change in default axis for interpolation",
                 "i" = "The default axis in the interpolation has changed from `axis = c(min=0.2, max=10, by = 8E-4)` to `axis = NULL`",
@@ -107,7 +107,7 @@ interpolate_1d <- function(list_of_ppms, list_of_1r, ppm_axis) {
                 if (requested_range[1] < native_range[1] || requested_range[2] > native_range[2]) {
                     below <- max(0, native_range[1] - requested_range[1])
                     above <- max(0, requested_range[2] - native_range[2])
-                    rlang::warn(
+                    cli::cli_warn(
                         message = c(
                             paste0(
                                 "Requested interpolation axis exceeds the native ppm range for sample ", i,

--- a/R/nmr_meta.R
+++ b/R/nmr_meta.R
@@ -37,7 +37,7 @@ nmr_meta_get <- function(samples,
     if (is.null(columns) && !is.null(groups)) {
         if (!all(groups %in% names(metadata_list))) {
             groups_miss <- groups[!groups %in% names(metadata_list)]
-            rlang::abort(message = c(
+            cli::cli_abort(message = c(
                 "Some missing groups in the dataset were requested:",
                 groups_miss
             ))
@@ -72,7 +72,7 @@ nmr_meta_get <- function(samples,
         if (length(cols_miss) - show_cols > 0) {
             err_msg <- c(err_msg, glue("and {length(cols_miss) - show_cols} more columns"))
         }
-        rlang::abort(message = err_msg)
+        cli::cli_abort(message = err_msg)
     }
 
     columns <- columns[columns %in% colnames(metadata)]

--- a/R/nmr_normalize.R
+++ b/R/nmr_normalize.R
@@ -6,7 +6,7 @@
 norm_pqn <- function(spectra, basel = NULL) {
     num_samples <- nrow(spectra)
     if (num_samples < 10) {
-        rlang::warn(
+        cli::cli_warn(
             message = c(
                 "There are not enough samples for reliably estimating the median spectra",
                 "i" = paste0(
@@ -34,7 +34,7 @@ norm_pqn <- function(spectra, basel = NULL) {
     areas <- areas / areas_median
     if (num_samples == 1) {
         # We have warned, and here there is nothing to do anymore
-        rlang::warn("PQN is meaningless with a single sample. We have normalized it to the area.")
+        cli::cli_warn("PQN is meaningless with a single sample. We have normalized it to the area.")
         out <- list(
             spectra = spectra / areas,
             norm_factor = areas
@@ -158,7 +158,7 @@ nmr_normalize <- function(samples,
         stop("Unimplemented method: ", method)
     }
     if (any(norm_factor <= 0)) {
-        rlang::warn(
+        cli::cli_warn(
             message = c(
                 "Normalization produced a non-positive factor for at least one sample",
                 "i" = "This may indicate a data-quality issue (e.g. an over-subtracted baseline)",

--- a/R/nmr_peak_clustering.R
+++ b/R/nmr_peak_clustering.R
@@ -128,7 +128,7 @@ nmr_peak_clustering <- function(peak_data, peak2peak_dist = NULL, num_clusters =
         if (is.null(max_dist_thresh_ppb)) {
             max_dist_thresh_ppb <- signif(3 * stats::median(peak_data$gamma_ppb), digits = 2)
             if (verbose) {
-                rlang::inform(c("i" = glue("The maximum distance between two peaks in the same cluster is of {max_dist_thresh_ppb} ppbs")))
+                cli::cli_inform(c("i" = glue("The maximum distance between two peaks in the same cluster is of {max_dist_thresh_ppb} ppbs")))
             }
         }
         num_cluster_estimation <- estimate_num_clusters(
@@ -160,7 +160,7 @@ nmr_peak_clustering <- function(peak_data, peak2peak_dist = NULL, num_clusters =
 
     if (nrow(wrong_clusters) > 0) {
         wrong_peak_ids <- purrr::flatten_chr(wrong_clusters$peak_ids)
-        rlang::warn(
+        cli::cli_warn(
             message = c(
                 glue("Ambiguity detected in the peak clustering affecting {length(wrong_peak_ids)} out of {nrow(peak_data)} peaks in the dataset"),
                 "i" = "Some samples have more than one peak in the same cluster.",
@@ -256,7 +256,7 @@ estimate_num_clusters <- function(peak_list, cluster, max_dist_thresh_ppb) {
         ggplot2::geom_hline(yintercept = max_dist_thresh_ppb, color = "gray") +
         ggplot2::labs(x = "Number of clusters", y = "Max distance within cluster (ppb)")
     if (length(num_clusters) == 0) {
-        rlang::abort(
+        cli::cli_abort(
             c(
                 "Can't find a suitable number of clusters",
                 "Probably the distance threshold is too small",
@@ -295,7 +295,7 @@ estimate_num_clusters <- function(peak_list, cluster, max_dist_thresh_ppb) {
 #'
 nmr_peak_clustering_plot <- function(dataset, peak_list_clustered, NMRExperiments, chemshift_range, baselineThresh = NULL) {
     if (length(NMRExperiments) != 2) {
-        rlang::abort("Please provide 2 and only 2 NMRExperiments")
+        cli::cli_abort("Please provide 2 and only 2 NMRExperiments")
     }
 
     tidy_data <- tidy_spectra_baseline_and_threshold(

--- a/R/plots.R
+++ b/R/plots.R
@@ -351,7 +351,7 @@ tidy.nmr_dataset_1D <-
                 valid_examples <- paste(utils::head(names(x), 2), collapse = ", ")
                 unknown_values <- paste(NMRExperiment[is_unknown], collapse = ", ")
                 if (all(is_unknown)) {
-                    rlang::abort(
+                    cli::cli_abort(
                         message = c(
                             "None of the given NMRExperiment values were found in the dataset",
                             "x" = glue::glue("Not found: {unknown_values}"),
@@ -496,7 +496,7 @@ plot_interactive <- function(plt, html_filename, overwrite = NULL) {
     if (is.null(overwrite) && libdir_exists) {
         if (interactive()) {
             # warning user before some contents of lib folder could be destroyed
-            rlang::inform("{libdir} folder already exists, plot_interactive will replace it. Continue? [y/n]:")
+            cli::cli_inform("{libdir} folder already exists, plot_interactive will replace it. Continue? [y/n]:")
             response <- scan("stdin", character(), n = 1)
             overwrite <- response %in% c("y", "Y")
         } else {
@@ -504,7 +504,7 @@ plot_interactive <- function(plt, html_filename, overwrite = NULL) {
         }
     }
     if (libdir_exists && isFALSE(overwrite)) {
-        rlang::abort(message = c("plot_interactive aborted", "x" = "{libdir} folder already exists, use overwrite=TRUE"))
+        cli::cli_abort(message = c("plot_interactive aborted", "x" = "{libdir} folder already exists, use overwrite=TRUE"))
     }
     suppressMessages(utils::capture.output({
         htmltools::save_html(

--- a/R/plsda.R
+++ b/R/plsda.R
@@ -24,7 +24,7 @@ plsda_build <- function(x, y, identity, ncomp) {
         },
         error = function(e) {
             msg <- conditionMessage(e)
-            rlang::abort(
+            cli::cli_abort(
                 message = c(
                     "plsda_build failed",
                     "i" = glue::glue("Original message: {msg}")
@@ -73,7 +73,7 @@ plsda_auroc <-
             },
             error = function(e) {
                 msg <- conditionMessage(e)
-                rlang::abort(
+                cli::cli_abort(
                     message = c(
                         "Area Under Curve estimation failed",
                         "i" = glue::glue("Original message: {msg}")
@@ -113,7 +113,7 @@ plsda_vip <- function(plsda_model) {
         },
         error = function(e) {
             msg <- conditionMessage(e)
-            rlang::inform(
+            cli::cli_inform(
                 message = c(
                     "VIP calculation failed",
                     "i" = glue::glue("Original message: {msg}")

--- a/R/utils.R
+++ b/R/utils.R
@@ -301,7 +301,7 @@ to_ASICS <- function(dataset, ...) {
 
 abort_if_not <- function(condition, ...) {
     if (!condition) {
-        rlang::abort(...)
+        cli::cli_abort(...)
     }
 }
 
@@ -314,7 +314,7 @@ require_pkgs <- function(pkg, msgs = NULL, ...) {
     if (!all(have_pkgs)) {
         missing_pkgs <- names(have_pkgs)[!have_pkgs]
         parent_call <- format(rlang::caller_call())
-        rlang::abort(
+        cli::cli_abort(
             message = c(
                 glue::glue("{parent_call} requires additional packages. Please install them. You may want to use:", parent_call = parent_call),
                 glue::glue("    BiocManager::install({deparse(missing_pkgs)})", missing_pkgs = missing_pkgs),
@@ -329,7 +329,7 @@ require_pkgs <- function(pkg, msgs = NULL, ...) {
 get_geom_text <- function() {
     has_ggrepel <- requireNamespace("ggrepel", quietly = TRUE)
     if (!has_ggrepel) {
-        rlang::warn(
+        cli::cli_warn(
             message = c(
                 "Text labels in the plot may overlap",
                 "i" = 'You may use `install.packages("ggrepel")` to install the ggrepel package',

--- a/tests/testthat/test-nmr_dataset_load_save.R
+++ b/tests/testthat/test-nmr_dataset_load_save.R
@@ -4,18 +4,23 @@ test_that("nmr_dataset_load() rejects an .rds file that is not a valid AlpsNMR d
     # unrelated .rds file must not be silently treated as a valid dataset --
     # it must be rejected with a clear error instead of returning garbage
     # that downstream code would then operate on.
+    # cli::cli_abort() word-wraps long messages to the console width, so the
+    # regexp is matched against whitespace-collapsed text rather than the raw
+    # (possibly wrapped) condition message.
     bad_file_list <- withr::local_tempfile(fileext = ".rds")
     saveRDS(list(foo = "bar"), bad_file_list)
-    expect_error(
-        nmr_dataset_load(bad_file_list),
-        regexp = "does not contain a valid AlpsNMR dataset"
+    err_list <- tryCatch(nmr_dataset_load(bad_file_list), error = function(e) e)
+    expect_match(
+        gsub("\\s+", " ", conditionMessage(err_list)),
+        "does not contain a valid AlpsNMR dataset"
     )
 
     bad_file_scalar <- withr::local_tempfile(fileext = ".rds")
     saveRDS(42, bad_file_scalar)
-    expect_error(
-        nmr_dataset_load(bad_file_scalar),
-        regexp = "does not contain a valid AlpsNMR dataset"
+    err_scalar <- tryCatch(nmr_dataset_load(bad_file_scalar), error = function(e) e)
+    expect_match(
+        gsub("\\s+", " ", conditionMessage(err_scalar)),
+        "does not contain a valid AlpsNMR dataset"
     )
 })
 


### PR DESCRIPTION
## Summary

The package already imports `cli` and uses `cli::cli_abort()` / `cli_warn()` / `cli_inform()` in about 20 call sites (`plots.R`, `plsda.R`, `nmr_autophase.R`, `nmr_data_analysis.R`, `pca_helpers.R`, `nmr_data_analysis_bp_vip.R`, `nmr_baseline_threshold.R`, `download_MTBLS242.R`), but 49 other call sites across 16 files still used `rlang::abort()` / `rlang::inform()` / `rlang::warn()` — an inconsistency left over from before `cli` was adopted.

This PR converts all of them to the `cli` equivalents, so the whole package uses one consistent API for user-facing conditions.

- `rlang::abort(` → `cli::cli_abort(`
- `rlang::inform(` → `cli::cli_inform(`
- `rlang::warn(` → `cli::cli_warn(`

The `message =` argument (including named bullet vectors like `c("i" = ..., "x" = ...)`) is accepted identically by both, so this is a mechanical rename. `rlang` remains a dependency — it's still used directly for other things (`rlang::enquos()`, `rlang::sym()`, `rlang::caller_env()`, etc.), untouched here.

## Behavior note

`cli_abort()`/`cli_warn()`/`cli_inform()` word-wrap long single-string messages to the console width; plain `rlang::abort()` messages didn't get wrapped the same way. Two `nmr_dataset_load()` tests asserted on the raw condition text spanning what became a wrap point, so they were changed to match against whitespace-collapsed text instead (functionally equivalent, just robust to where the wrap lands).

## Testing

`devtools::test()` — full suite passes (702 tests, all green; the 1 warning and 1 skip are pre-existing and unrelated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXge48MtnR7KNWzCh34uAn)_