### PR TITLE
Verify SHA-256 checksums in download_MTBLS242()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -102,6 +102,7 @@ Suggests:
     GGally (>= 2.2.1),
     ggrepel (>= 0.9.6),
     gridExtra (>= 2.3),
+    jsonlite (>= 1.8.9),
     knitr (>= 1.50),
     NMRphasing (>= 1.0.7),
     plotly (>= 4.11.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -97,6 +97,7 @@ Suggests:
     ChemoSpec (>= 6.2.0),
     cowplot (>= 1.2.0),
     curl (>= 6.4.0),
+    digest (>= 0.6.35),
     DT (>= 0.33),
     GGally (>= 2.2.1),
     ggrepel (>= 0.9.6),

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,21 +47,8 @@
 
 ## Other changes
 
-- `download_MTBLS242()`: still downloads the dataset over FTP, as documented
-  by MetaboLights, but now verifies every freshly downloaded file against
-  the canonical SHA-256 checksums MetaboLights publishes for MTBLS242
-  (`<https_url>/HASHES/{metadata,data}_sha256.json`, fetched over HTTPS —
-  the only part of this fix that uses HTTPS, since MetaboLights does not
-  document that path as a supported way to download the data files
-  themselves), aborting with a clear error on mismatch instead of silently
-  accepting a corrupted or tampered file. As a fallback for when that
-  manifest can't be fetched, the SHA-256 of every downloaded file is also
-  pinned to `<dest_dir>/SHA256SUMS` the first time it is saved and
-  re-verified on every later call that reuses a cached file (#72). Also
-  fixes the sample data URLs, which 404'd against the current server layout
-  (missing a `FILES/` path segment) and metadata filename casing
-  (`s_mtbls242.txt` vs. the server's `s_MTBLS242.txt`).
-  Adds `digest` and `jsonlite` as new `Suggests` dependencies.
+- `download_MTBLS242()`: validate downloaded files against MetaboLights'
+  published SHA-256 checksums for the MTBLS242 dataset (#72).
 - Bumped several dependency version floors to roughly their versions from a
   year ago. Packages with a recent major release are pinned to the last
   minor of the previous major instead, to avoid forcing an upgrade:

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,18 +47,19 @@
 
 ## Other changes
 
-- `download_MTBLS242()`: now downloads the dataset over HTTPS instead of
-  plain, unauthenticated FTP (EBI mirrors the same file tree at
-  `https://ftp.ebi.ac.uk/...`), and verifies every freshly downloaded file
-  against the canonical SHA-256 checksums MetaboLights publishes for
-  MTBLS242 (`<url>/HASHES/{metadata,data}_sha256.json`), aborting with a
-  clear error on mismatch instead of silently accepting a corrupted or
-  tampered file. As a fallback for when that manifest can't be fetched, the
-  SHA-256 of every downloaded file is also pinned to
-  `<dest_dir>/SHA256SUMS` the first time it is saved and re-verified on
-  every later call that reuses a cached file (#72). Also fixes the sample
-  data URLs, which 404'd against the current server layout (missing a
-  `FILES/` path segment) and metadata filename casing
+- `download_MTBLS242()`: still downloads the dataset over FTP, as documented
+  by MetaboLights, but now verifies every freshly downloaded file against
+  the canonical SHA-256 checksums MetaboLights publishes for MTBLS242
+  (`<https_url>/HASHES/{metadata,data}_sha256.json`, fetched over HTTPS —
+  the only part of this fix that uses HTTPS, since MetaboLights does not
+  document that path as a supported way to download the data files
+  themselves), aborting with a clear error on mismatch instead of silently
+  accepting a corrupted or tampered file. As a fallback for when that
+  manifest can't be fetched, the SHA-256 of every downloaded file is also
+  pinned to `<dest_dir>/SHA256SUMS` the first time it is saved and
+  re-verified on every later call that reuses a cached file (#72). Also
+  fixes the sample data URLs, which 404'd against the current server layout
+  (missing a `FILES/` path segment) and metadata filename casing
   (`s_mtbls242.txt` vs. the server's `s_MTBLS242.txt`).
   Adds `digest` and `jsonlite` as new `Suggests` dependencies.
 - Bumped several dependency version floors to roughly their versions from a

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,14 @@
 
 ## Other changes
 
+- `download_MTBLS242()`: the SHA-256 of every downloaded file is now pinned
+  to `<dest_dir>/SHA256SUMS` the first time it is saved, and re-verified
+  against that pinned value on every later call that reuses a cached file
+  (including cache hits with `force = FALSE`), aborting with a clear error on
+  mismatch instead of silently reusing a corrupted or tampered file. This
+  does not protect the very first download of a file, since MetaboLights
+  does not publish a canonical checksum for it to be verified against (#72).
+  Adds `digest` as a new `Suggests` dependency.
 - Bumped several dependency version floors to roughly their versions from a
   year ago. Packages with a recent major release are pinned to the last
   minor of the previous major instead, to avoid forcing an upgrade:

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,14 +47,20 @@
 
 ## Other changes
 
-- `download_MTBLS242()`: the SHA-256 of every downloaded file is now pinned
-  to `<dest_dir>/SHA256SUMS` the first time it is saved, and re-verified
-  against that pinned value on every later call that reuses a cached file
-  (including cache hits with `force = FALSE`), aborting with a clear error on
-  mismatch instead of silently reusing a corrupted or tampered file. This
-  does not protect the very first download of a file, since MetaboLights
-  does not publish a canonical checksum for it to be verified against (#72).
-  Adds `digest` as a new `Suggests` dependency.
+- `download_MTBLS242()`: now downloads the dataset over HTTPS instead of
+  plain, unauthenticated FTP (EBI mirrors the same file tree at
+  `https://ftp.ebi.ac.uk/...`), and verifies every freshly downloaded file
+  against the canonical SHA-256 checksums MetaboLights publishes for
+  MTBLS242 (`<url>/HASHES/{metadata,data}_sha256.json`), aborting with a
+  clear error on mismatch instead of silently accepting a corrupted or
+  tampered file. As a fallback for when that manifest can't be fetched, the
+  SHA-256 of every downloaded file is also pinned to
+  `<dest_dir>/SHA256SUMS` the first time it is saved and re-verified on
+  every later call that reuses a cached file (#72). Also fixes the sample
+  data URLs, which 404'd against the current server layout (missing a
+  `FILES/` path segment) and metadata filename casing
+  (`s_mtbls242.txt` vs. the server's `s_MTBLS242.txt`).
+  Adds `digest` and `jsonlite` as new `Suggests` dependencies.
 - Bumped several dependency version floors to roughly their versions from a
   year ago. Packages with a recent major release are pinned to the last
   minor of the previous major instead, to avoid forcing an upgrade:

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -30,9 +30,14 @@
 #' doesn't download their data.
 #' 
 #' 
-#' @param dest_dir Directory where the dataset should be saved
+#' @param dest_dir Directory where the dataset should be saved. The SHA-256
+#' checksum of every downloaded file is pinned to `<dest_dir>/SHA256SUMS` the
+#' first time it is saved, and re-verified on every later call that reuses a
+#' cached file, so local corruption or tampering between calls is detected.
 #' @param force Logical. If `TRUE` we do not re-download files if they exist. The function does not check whether cached versions were
 #' downloaded with different `keep_only_*` arguments, so please use `force = TRUE` if you change the `keep_only_*` settings.
+#' `force = TRUE` also re-downloads and re-pins the checksum of every file, rather than
+#' verifying it against a previously pinned value.
 #' @param keep_only_CPMG_1r If `TRUE`, remove all other data beyond the CPMG real spectrum, which is enough for the tutorial
 #' @param keep_only_preop_and_3months If `TRUE`, keep only the preoperatory and the "three months after surgery" time points, enough for the tutorial
 #' @param keep_only_complete_time_points If `TRUE`, remove samples that do not appear on all timepoints. Useful for the tutorial.
@@ -56,13 +61,20 @@ download_MTBLS242 <- function(
         keep_only_preop_and_3months = TRUE,
         keep_only_complete_time_points = TRUE
     ) {
-    require_pkgs(pkg = c("curl", "zip"))
-    # NOTE (security): this dataset is fetched over plain, unauthenticated FTP and this
-    # function performs no checksum/integrity verification of the downloaded files. The
-    # retrieved data should therefore not be treated as tamper-proof. A future improvement
-    # would be to compute and verify a SHA-256 checksum of each downloaded file once a
-    # canonical, trusted hash is obtained from the data provider (e.g. published alongside
-    # the dataset on MetaboLights/EBI).
+    require_pkgs(pkg = c("curl", "zip", "digest"))
+    # NOTE (security): this dataset is fetched over plain, unauthenticated FTP.
+    # MetaboLights' public API and its FTP server do not publish a canonical
+    # checksum for these files, so a freshly downloaded file cannot be verified
+    # against a hash obtained from the data provider itself: a network-position
+    # attacker or a compromised mirror could still tamper with the very first
+    # download of a given file undetected.
+    # What we *can* guarantee is integrity across runs: the SHA-256 of every
+    # downloaded file is pinned to `<dest_dir>/SHA256SUMS` the first time it is
+    # saved, and is re-verified against that pinned value on every later call
+    # that reuses the cached file (including cache hits with `force = FALSE`).
+    # This reliably detects local corruption or tampering of previously
+    # downloaded files and aborts loudly; pass `force = TRUE` to intentionally
+    # re-download and re-pin a file.
     url <- "ftp://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS242/"
 
     dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
@@ -80,6 +92,7 @@ download_MTBLS242 <- function(
         cli::cli_inform(c("i" = "Downloading sample annotations..."))
         curl_download_retry(url = meta_url, destfile = annotations_orig_destfile)
     }
+    verify_or_pin_checksum(dest_dir, annotations_orig_destfile, meta_file)
     if (!file.exists(annotations_destfile) || force) {
         sample_annot <- tibble::as_tibble(
             utils::read.table(
@@ -154,7 +167,7 @@ download_MTBLS242 <- function(
     report_skipped_downloads <- FALSE
     purrr::walk(
         sample_annot$NMRExperiment,
-        function(filename_base, url, dst_rootdir, keep_only_CPMG_1r) {
+        function(filename_base, url, dst_rootdir, dest_dir, keep_only_CPMG_1r) {
             filename <- paste0(filename_base, ".zip")
             src_url <- file.path(url, filename)
             final_dst_file <- file.path(dst_rootdir, filename)
@@ -164,11 +177,13 @@ download_MTBLS242 <- function(
                     cli::cli_inform(c("i" = "Skipping re-download of previously downloaded samples."))
                     report_skipped_downloads <<- TRUE
                 }
+                verify_or_pin_checksum(dest_dir, final_dst_file, fs::path_rel(final_dst_file, dest_dir))
                 return()
             }
             curl_download_retry(url = src_url, destfile = intermediate_dst_file)
             if (!keep_only_CPMG_1r) {
                 file.rename(intermediate_dst_file, final_dst_file)
+                verify_or_pin_checksum(dest_dir, final_dst_file, fs::path_rel(final_dst_file, dest_dir))
             } else {
                 filenames_in_zip <- zip::zip_list(intermediate_dst_file)[["filename"]]
                 prefix_to_keep <- file.path(filename_base, "3", "") # subdirectory 3/ contains the CPMG sample
@@ -208,10 +223,12 @@ download_MTBLS242 <- function(
                 )
                 # And once you have the zip file, remove the directory:
                 unlink(file.path(dst_rootdir, filename_base), recursive = TRUE)
+                verify_or_pin_checksum(dest_dir, final_dst_file, fs::path_rel(final_dst_file, dest_dir))
             }
         },
         url = url,
         dst_rootdir = dst_rootdir,
+        dest_dir = dest_dir,
         keep_only_CPMG_1r = keep_only_CPMG_1r,
         .progress = "Downloading and preparing samples..."
     )
@@ -251,4 +268,60 @@ curl_download_retry <- function(url, destfile, ..., timeout_retries = 3) {
         attempts <- attempts + 1
     }
     stop("Download failed too many times. Retry later or fix the URL")
+}
+
+sha256_file <- function(path) {
+    digest::digest(path, algo = "sha256", file = TRUE)
+}
+
+checksum_manifest_path <- function(dest_dir) {
+    file.path(dest_dir, "SHA256SUMS")
+}
+
+# Reads `<dest_dir>/SHA256SUMS` (`sha256sum`-format: "<64-hex-digit hash>  <path>"
+# per line) into a character vector of hashes named by their relative path, so
+# the manifest can also be checked independently with `sha256sum -c SHA256SUMS`.
+read_checksum_manifest <- function(dest_dir) {
+    path <- checksum_manifest_path(dest_dir)
+    if (!file.exists(path)) {
+        return(character(0))
+    }
+    lines <- readLines(path, warn = FALSE)
+    lines <- lines[nzchar(lines)]
+    hashes <- substr(lines, 1, 64)
+    paths <- substring(lines, 67)
+    stats::setNames(hashes, paths)
+}
+
+write_checksum_manifest_entry <- function(dest_dir, relative_path, sha256) {
+    manifest <- read_checksum_manifest(dest_dir)
+    manifest[relative_path] <- sha256
+    manifest <- manifest[order(names(manifest))]
+    lines <- paste0(manifest, "  ", names(manifest))
+    writeLines(lines, checksum_manifest_path(dest_dir))
+}
+
+# Pins the SHA-256 of `file` (recorded under `relative_path`, relative to
+# `dest_dir`) to `<dest_dir>/SHA256SUMS` the first time it is seen, and
+# verifies `file` against that pinned value on every later call that reuses
+# the cached file. See the NOTE (security) comment in download_MTBLS242()
+# for why this cannot verify the very first download against a hash obtained
+# from the data provider.
+verify_or_pin_checksum <- function(dest_dir, file, relative_path) {
+    manifest <- read_checksum_manifest(dest_dir)
+    actual <- sha256_file(file)
+    expected <- unname(manifest[relative_path])
+    if (is.na(expected)) {
+        write_checksum_manifest_entry(dest_dir, relative_path, actual)
+        return(invisible(actual))
+    }
+    if (!identical(actual, expected)) {
+        cli::cli_abort(c(
+            "x" = "Checksum mismatch for {.file {file}}.",
+            "i" = "Expected SHA-256 {.val {expected}} (recorded the first time this file was downloaded) but got {.val {actual}}.",
+            "i" = "The file may be corrupted or have been modified locally since it was downloaded.",
+            "i" = "Delete it (or pass {.code force = TRUE}) to re-download and re-pin it."
+        ))
+    }
+    invisible(actual)
 }

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -23,17 +23,20 @@
 #' download function and it will restart from where it stopped.
 #' 
 #' Note as well, that we observed several files to have incorrect data:
-#' - Obs4_0346s.zip is not present in the FTP server
+#' - Obs4_0346s.zip is not present on the server
 #' - Obs0_0110s.zip and Obs1_0256s.zip incorrectly contain sample Obs1_0010s
 #' 
 #' This function removes all three samples from the samples annotations and
 #' doesn't download their data.
 #' 
 #' 
-#' @param dest_dir Directory where the dataset should be saved. The SHA-256
-#' checksum of every downloaded file is pinned to `<dest_dir>/SHA256SUMS` the
-#' first time it is saved, and re-verified on every later call that reuses a
-#' cached file, so local corruption or tampering between calls is detected.
+#' @param dest_dir Directory where the dataset should be saved. Every freshly
+#' downloaded file is verified against the canonical SHA-256 checksums
+#' MetaboLights publishes for MTBLS242. As a fallback for when that manifest
+#' cannot be fetched, the SHA-256 of every downloaded file is also pinned to
+#' `<dest_dir>/SHA256SUMS` the first time it is saved, and re-verified on
+#' every later call that reuses a cached file, so local corruption or
+#' tampering between calls is detected either way.
 #' @param force Logical. If `TRUE` we do not re-download files if they exist. The function does not check whether cached versions were
 #' downloaded with different `keep_only_*` arguments, so please use `force = TRUE` if you change the `keep_only_*` settings.
 #' `force = TRUE` also re-downloads and re-pins the checksum of every file, rather than
@@ -61,27 +64,38 @@ download_MTBLS242 <- function(
         keep_only_preop_and_3months = TRUE,
         keep_only_complete_time_points = TRUE
     ) {
-    require_pkgs(pkg = c("curl", "zip", "digest"))
-    # NOTE (security): this dataset is fetched over plain, unauthenticated FTP.
-    # MetaboLights' public API and its FTP server do not publish a canonical
-    # checksum for these files, so a freshly downloaded file cannot be verified
-    # against a hash obtained from the data provider itself: a network-position
-    # attacker or a compromised mirror could still tamper with the very first
-    # download of a given file undetected.
-    # What we *can* guarantee is integrity across runs: the SHA-256 of every
-    # downloaded file is pinned to `<dest_dir>/SHA256SUMS` the first time it is
-    # saved, and is re-verified against that pinned value on every later call
-    # that reuses the cached file (including cache hits with `force = FALSE`).
-    # This reliably detects local corruption or tampering of previously
-    # downloaded files and aborts loudly; pass `force = TRUE` to intentionally
-    # re-download and re-pin a file.
-    url <- "ftp://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS242/"
+    require_pkgs(pkg = c("curl", "zip", "digest", "jsonlite"))
+    # NOTE (security): this dataset used to be fetched over plain, unauthenticated
+    # FTP. EBI also mirrors the very same MTBLS242 file tree over HTTPS, so we now
+    # fetch everything over HTTPS instead: the transfer itself is encrypted and the
+    # server is authenticated via the usual TLS certificate chain, closing the
+    # original "a network-position attacker could alter the data in transit"
+    # concern for the download itself.
+    # On top of that, EBI publishes canonical SHA-256 checksums for MTBLS242's
+    # metadata and per-sample data files at `<url>/HASHES/{metadata,data}_sha256.json`
+    # (also served over HTTPS). Every freshly downloaded file is verified against
+    # those provider-published hashes right after download, before any local
+    # extraction/repacking, and the function aborts loudly on a mismatch instead of
+    # silently accepting a corrupted or tampered file.
+    # If that canonical manifest cannot be fetched (e.g. a transient network issue),
+    # we fall back to a local safety net: the SHA-256 of every file that persists on
+    # disk (`<dest_dir>/SHA256SUMS`) is pinned the first time it is seen and
+    # re-verified on every later call that reuses the cached file (including cache
+    # hits with `force = FALSE`), which still catches local corruption or tampering
+    # between calls even without a canonical source. This local pin cannot verify a
+    # file's very first download; pass `force = TRUE` to intentionally re-download
+    # and re-verify/re-pin a file.
+    url <- "https://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS242"
+    canonical_hashes <- fetch_canonical_checksums(url)
 
     dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
 
-    # Download metadata file s_mtbls242.txt
+    # Download metadata file (the file is actually named "s_MTBLS242.txt" on the
+    # server; we keep saving it locally as lowercase "s_mtbls242.txt" for backwards
+    # compatibility with previously downloaded caches).
+    remote_meta_file <- "s_MTBLS242.txt"
     meta_file <- "s_mtbls242.txt"
-    meta_url <- file.path(url, meta_file)
+    meta_url <- file.path(url, remote_meta_file)
 
     # meta_dst <- file.path(dest_dir, meta_file)
     # utils::download.file(meta_url, method = "auto", destfile = meta_dst, mode = "wb")
@@ -91,6 +105,7 @@ download_MTBLS242 <- function(
     if (!file.exists(annotations_orig_destfile) || force) {
         cli::cli_inform(c("i" = "Downloading sample annotations..."))
         curl_download_retry(url = meta_url, destfile = annotations_orig_destfile)
+        verify_canonical_checksum(annotations_orig_destfile, canonical_hashes, remote_meta_file)
     }
     verify_or_pin_checksum(dest_dir, annotations_orig_destfile, meta_file)
     if (!file.exists(annotations_destfile) || force) {
@@ -131,7 +146,7 @@ download_MTBLS242 <- function(
         sample_annot <- dplyr::filter(sample_annot, .data$NMRExperiment != "Obs0_0110s")
         # File Obs1_0256s.zip incorrectly contains Obs1_0010s. Remove that ID
         sample_annot <- dplyr::filter(sample_annot, .data$NMRExperiment != "Obs1_0256s")
-        # File Obs4_0346s.zip does not exist in the FTP server, remove that entry:
+        # File Obs4_0346s.zip does not exist on the server, remove that entry:
         sample_annot <- dplyr::filter(sample_annot, .data$NMRExperiment != "Obs4_0346s")
 
         
@@ -167,9 +182,10 @@ download_MTBLS242 <- function(
     report_skipped_downloads <- FALSE
     purrr::walk(
         sample_annot$NMRExperiment,
-        function(filename_base, url, dst_rootdir, dest_dir, keep_only_CPMG_1r) {
+        function(filename_base, url, dst_rootdir, dest_dir, keep_only_CPMG_1r, canonical_hashes) {
             filename <- paste0(filename_base, ".zip")
-            src_url <- file.path(url, filename)
+            src_url <- file.path(url, "FILES", filename)
+            canonical_key <- paste0("FILES/", filename)
             final_dst_file <- file.path(dst_rootdir, filename)
             intermediate_dst_file <- file.path(dst_rootdir, paste0(filename, "intermediate.zip"))
             if (file.exists(final_dst_file) && !force) {
@@ -181,6 +197,10 @@ download_MTBLS242 <- function(
                 return()
             }
             curl_download_retry(url = src_url, destfile = intermediate_dst_file)
+            # Verify the raw download against MetaboLights' published checksum
+            # before touching it any further (extraction/repacking below would
+            # otherwise obscure whether the *downloaded* bytes were intact).
+            verify_canonical_checksum(intermediate_dst_file, canonical_hashes, canonical_key)
             if (!keep_only_CPMG_1r) {
                 file.rename(intermediate_dst_file, final_dst_file)
                 verify_or_pin_checksum(dest_dir, final_dst_file, fs::path_rel(final_dst_file, dest_dir))
@@ -230,6 +250,7 @@ download_MTBLS242 <- function(
         dst_rootdir = dst_rootdir,
         dest_dir = dest_dir,
         keep_only_CPMG_1r = keep_only_CPMG_1r,
+        canonical_hashes = canonical_hashes,
         .progress = "Downloading and preparing samples..."
     )
     invisible(sample_annot)
@@ -274,6 +295,55 @@ sha256_file <- function(path) {
     digest::digest(path, algo = "sha256", file = TRUE)
 }
 
+# Fetches the SHA-256 checksums MetaboLights publishes for MTBLS242's
+# metadata and per-sample data files (`<url>/HASHES/{metadata,data}_sha256.json`)
+# and returns them merged into a single character vector of hashes named by
+# their path relative to `url` (e.g. "s_MTBLS242.txt", "FILES/Obs0_0001s.zip").
+# Returns NULL (with a warning) if the manifest cannot be fetched, so callers
+# can fall back to a weaker, local-only integrity check.
+fetch_canonical_checksums <- function(url) {
+    tmp_metadata <- tempfile(fileext = ".json")
+    tmp_data <- tempfile(fileext = ".json")
+    on.exit(unlink(c(tmp_metadata, tmp_data)))
+    tryCatch({
+        curl_download_retry(url = file.path(url, "HASHES", "metadata_sha256.json"), destfile = tmp_metadata)
+        curl_download_retry(url = file.path(url, "HASHES", "data_sha256.json"), destfile = tmp_data)
+        c(
+            unlist(jsonlite::fromJSON(tmp_metadata)),
+            unlist(jsonlite::fromJSON(tmp_data))
+        )
+    }, error = function(e) {
+        cli::cli_warn(c(
+            "!" = "Could not fetch the SHA-256 checksums MetaboLights publishes for MTBLS242 ({conditionMessage(e)}).",
+            "i" = "Downloaded files will only be checked for integrity across runs, not verified against the data provider on first download."
+        ))
+        NULL
+    })
+}
+
+# Verifies `file`'s SHA-256 against the canonical hash MetaboLights published
+# for `canonical_key`, if one was fetched. Silently does nothing if no
+# canonical manifest is available, or if it has no entry for `canonical_key`.
+verify_canonical_checksum <- function(file, canonical_hashes, canonical_key) {
+    if (is.null(canonical_hashes)) {
+        return(invisible(NULL))
+    }
+    canonical <- unname(canonical_hashes[canonical_key])
+    if (is.na(canonical)) {
+        return(invisible(NULL))
+    }
+    actual <- sha256_file(file)
+    if (!identical(actual, canonical)) {
+        cli::cli_abort(c(
+            "x" = "Checksum mismatch for {.file {file}}.",
+            "i" = "Expected SHA-256 {.val {canonical}}, published by MetaboLights for {.val {canonical_key}}, but got {.val {actual}}.",
+            "i" = "The downloaded file does not match the data provider's checksum and may have been corrupted or tampered with in transit.",
+            "i" = "Try downloading it again."
+        ))
+    }
+    invisible(actual)
+}
+
 checksum_manifest_path <- function(dest_dir) {
     file.path(dest_dir, "SHA256SUMS")
 }
@@ -301,12 +371,14 @@ write_checksum_manifest_entry <- function(dest_dir, relative_path, sha256) {
     writeLines(lines, checksum_manifest_path(dest_dir))
 }
 
-# Pins the SHA-256 of `file` (recorded under `relative_path`, relative to
-# `dest_dir`) to `<dest_dir>/SHA256SUMS` the first time it is seen, and
-# verifies `file` against that pinned value on every later call that reuses
-# the cached file. See the NOTE (security) comment in download_MTBLS242()
-# for why this cannot verify the very first download against a hash obtained
-# from the data provider.
+# Local-only fallback layer (see verify_canonical_checksum() for the
+# provider-verified one): pins the SHA-256 of `file` (recorded under
+# `relative_path`, relative to `dest_dir`) to `<dest_dir>/SHA256SUMS` the
+# first time it is seen, and verifies `file` against that pinned value on
+# every later call that reuses the cached file. This has no canonical source
+# to compare against (e.g. a locally repacked, CPMG-only archive has no
+# provider-published hash of its own), so it cannot catch tampering with a
+# file's very first download the way verify_canonical_checksum() can.
 verify_or_pin_checksum <- function(dest_dir, file, relative_path) {
     manifest <- read_checksum_manifest(dest_dir)
     actual <- sha256_file(file)

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -65,28 +65,33 @@ download_MTBLS242 <- function(
         keep_only_complete_time_points = TRUE
     ) {
     require_pkgs(pkg = c("curl", "zip", "digest", "jsonlite"))
-    # NOTE (security): this dataset used to be fetched over plain, unauthenticated
-    # FTP. EBI also mirrors the very same MTBLS242 file tree over HTTPS, so we now
-    # fetch everything over HTTPS instead: the transfer itself is encrypted and the
-    # server is authenticated via the usual TLS certificate chain, closing the
-    # original "a network-position attacker could alter the data in transit"
-    # concern for the download itself.
-    # On top of that, EBI publishes canonical SHA-256 checksums for MTBLS242's
-    # metadata and per-sample data files at `<url>/HASHES/{metadata,data}_sha256.json`
-    # (also served over HTTPS). Every freshly downloaded file is verified against
-    # those provider-published hashes right after download, before any local
-    # extraction/repacking, and the function aborts loudly on a mismatch instead of
-    # silently accepting a corrupted or tampered file.
-    # If that canonical manifest cannot be fetched (e.g. a transient network issue),
-    # we fall back to a local safety net: the SHA-256 of every file that persists on
-    # disk (`<dest_dir>/SHA256SUMS`) is pinned the first time it is seen and
+    # NOTE (security): this dataset is fetched over plain, unauthenticated FTP, as
+    # documented by MetaboLights (https://ebi-metabolights.github.io/guides/Files/,
+    # "If you want to download data files, you MUST use FTP, Aspera or Globus
+    # clients."). EBI happens to also mirror the same file tree over HTTPS at
+    # `https://ftp.ebi.ac.uk/...`, but that is not a documented, supported access
+    # path, so we don't rely on it for the actual downloads -- it could be
+    # reorganized or dropped without notice.
+    # We do use that same HTTPS mirror for one thing: EBI publishes canonical
+    # SHA-256 checksums for MTBLS242's metadata and per-sample data files at
+    # `<https_url>/HASHES/{metadata,data}_sha256.json` (also undocumented, but
+    # low-risk to depend on since it only affects checksum verification, not
+    # whether the download itself succeeds). Every freshly downloaded file is
+    # verified against those provider-published hashes right after download,
+    # before any local extraction/repacking, and the function aborts loudly on a
+    # mismatch instead of silently accepting a corrupted or tampered file.
+    # If that canonical manifest cannot be fetched (e.g. a transient network issue,
+    # or EBI removing this undocumented endpoint), we fall back to a local safety
+    # net: the SHA-256 of every file that persists on disk
+    # (`<dest_dir>/SHA256SUMS`) is pinned the first time it is seen and
     # re-verified on every later call that reuses the cached file (including cache
     # hits with `force = FALSE`), which still catches local corruption or tampering
     # between calls even without a canonical source. This local pin cannot verify a
     # file's very first download; pass `force = TRUE` to intentionally re-download
     # and re-verify/re-pin a file.
-    url <- "https://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS242"
-    canonical_hashes <- fetch_canonical_checksums(url)
+    url <- "ftp://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS242"
+    https_url <- "https://ftp.ebi.ac.uk/pub/databases/metabolights/studies/public/MTBLS242"
+    canonical_hashes <- fetch_canonical_checksums(https_url)
 
     dir.create(dest_dir, recursive = TRUE, showWarnings = FALSE)
 

--- a/man/download_MTBLS242.Rd
+++ b/man/download_MTBLS242.Rd
@@ -13,10 +13,13 @@ download_MTBLS242(
 )
 }
 \arguments{
-\item{dest_dir}{Directory where the dataset should be saved. The SHA-256
-checksum of every downloaded file is pinned to \verb{<dest_dir>/SHA256SUMS} the
-first time it is saved, and re-verified on every later call that reuses a
-cached file, so local corruption or tampering between calls is detected.}
+\item{dest_dir}{Directory where the dataset should be saved. Every freshly
+downloaded file is verified against the canonical SHA-256 checksums
+MetaboLights publishes for MTBLS242. As a fallback for when that manifest
+cannot be fetched, the SHA-256 of every downloaded file is also pinned to
+\verb{<dest_dir>/SHA256SUMS} the first time it is saved, and re-verified on
+every later call that reuses a cached file, so local corruption or
+tampering between calls is detected either way.}
 
 \item{force}{Logical. If \code{TRUE} we do not re-download files if they exist. The function does not check whether cached versions were
 downloaded with different \verb{keep_only_*} arguments, so please use \code{force = TRUE} if you change the \verb{keep_only_*} settings.
@@ -61,7 +64,7 @@ download function and it will restart from where it stopped.
 
 Note as well, that we observed several files to have incorrect data:
 \itemize{
-\item Obs4_0346s.zip is not present in the FTP server
+\item Obs4_0346s.zip is not present on the server
 \item Obs0_0110s.zip and Obs1_0256s.zip incorrectly contain sample Obs1_0010s
 }
 

--- a/man/download_MTBLS242.Rd
+++ b/man/download_MTBLS242.Rd
@@ -13,10 +13,15 @@ download_MTBLS242(
 )
 }
 \arguments{
-\item{dest_dir}{Directory where the dataset should be saved}
+\item{dest_dir}{Directory where the dataset should be saved. The SHA-256
+checksum of every downloaded file is pinned to \verb{<dest_dir>/SHA256SUMS} the
+first time it is saved, and re-verified on every later call that reuses a
+cached file, so local corruption or tampering between calls is detected.}
 
 \item{force}{Logical. If \code{TRUE} we do not re-download files if they exist. The function does not check whether cached versions were
-downloaded with different \verb{keep_only_*} arguments, so please use \code{force = TRUE} if you change the \verb{keep_only_*} settings.}
+downloaded with different \verb{keep_only_*} arguments, so please use \code{force = TRUE} if you change the \verb{keep_only_*} settings.
+\code{force = TRUE} also re-downloads and re-pins the checksum of every file, rather than
+verifying it against a previously pinned value.}
 
 \item{keep_only_CPMG_1r}{If \code{TRUE}, remove all other data beyond the CPMG real spectrum, which is enough for the tutorial}
 

--- a/tests/testthat/test-download_MTBLS242.R
+++ b/tests/testthat/test-download_MTBLS242.R
@@ -2,15 +2,14 @@ test_that("download_MTBLS242() rejects a zip archive with a path-traversal entry
     skip_if_not_installed("zip")
     skip_if_not_installed("fs")
 
-    # download_MTBLS242() downloads a zip archive over plain, unauthenticated
-    # FTP and extracts it locally. An archive entry name is not trustworthy:
-    # a maliciously (or accidentally) crafted entry can encode "../" segments
-    # that, once combined with the extraction root, resolve outside of it
-    # ("zip-slip"). Archives from an unauthenticated download must never be
-    # allowed to write outside the intended extraction directory, so
-    # download_MTBLS242() checks each entry's resolved path against the
-    # extraction root before calling zip::unzip() and aborts if any entry
-    # would escape it.
+    # download_MTBLS242() downloads a zip archive and extracts it locally. An
+    # archive entry name is not trustworthy regardless of how the archive was
+    # obtained: a maliciously (or accidentally) crafted entry can encode
+    # "../" segments that, once combined with the extraction root, resolve
+    # outside of it ("zip-slip"). Archive contents must never be allowed to
+    # write outside the intended extraction directory, so download_MTBLS242()
+    # checks each entry's resolved path against the extraction root before
+    # calling zip::unzip() and aborts if any entry would escape it.
     #
     # This test builds such a malicious archive and confirms the guard
     # rejects it before any extraction happens.
@@ -49,10 +48,13 @@ test_that("download_MTBLS242() rejects a zip archive with a path-traversal entry
     expect_true(any(grepl("\\.\\.", entry_names)))
 
     # --- Mock the only network-touching call so no real download happens ---
-    # The first call fetches the annotations metadata file, the second the
-    # (here: malicious) per-sample zip archive.
+    # The metadata file and the (here: malicious) per-sample zip archive are
+    # served; requests for MetaboLights' canonical SHA-256 manifest
+    # (HASHES/*.json) are deliberately left unhandled, so
+    # download_MTBLS242() falls back to its local-only integrity check,
+    # which is what this test is about.
     mock_curl_download_retry <- function(url, destfile, ...) {
-        if (grepl("s_mtbls242\\.txt$", url)) {
+        if (grepl("s_MTBLS242\\.txt$", url, ignore.case = TRUE)) {
             writeLines(
                 c("Sample Name\tFactor Value[time point]", "0-0001-1\tpreop"),
                 destfile
@@ -112,8 +114,11 @@ test_that("download_MTBLS242() extracts a benign zip archive normally", {
         zip::zip(zipfile = benign_zip, files = file.path("Obs0_0001s", "3", "1r"))
     })
 
+    # As above, HASHES/*.json requests are left unhandled on purpose so this
+    # test exercises the local-only fallback rather than canonical
+    # verification (covered separately below).
     mock_curl_download_retry <- function(url, destfile, ...) {
-        if (grepl("s_mtbls242\\.txt$", url)) {
+        if (grepl("s_MTBLS242\\.txt$", url, ignore.case = TRUE)) {
             writeLines(
                 c("Sample Name\tFactor Value[time point]", "0-0001-1\tpreop"),
                 destfile
@@ -142,19 +147,126 @@ test_that("download_MTBLS242() extracts a benign zip archive normally", {
     expect_true(file.exists(file.path(dst_rootdir, "Obs0_0001s.zip")))
 })
 
-test_that("download_MTBLS242() pins SHA-256 checksums and detects local tampering with cached files", {
+test_that("download_MTBLS242() verifies fresh downloads against MetaboLights' canonical SHA-256 manifest", {
+    skip_if_not_installed("zip")
+    skip_if_not_installed("fs")
+    skip_if_not_installed("digest")
+    skip_if_not_installed("jsonlite")
+
+    # MetaboLights publishes canonical SHA-256 checksums for MTBLS242's
+    # metadata and per-sample data files at
+    # <url>/HASHES/{metadata,data}_sha256.json, served over HTTPS. When that
+    # manifest is reachable, download_MTBLS242() verifies every freshly
+    # downloaded file against it directly -- not just against a value it
+    # pinned itself on a previous run -- so it also protects the very first
+    # download of a file against tampering or corruption in transit.
+    work_root <- withr::local_tempdir()
+    dest_dir <- file.path(work_root, "mtbls_test")
+    dst_rootdir <- file.path(dest_dir, "samples")
+    dir.create(dst_rootdir, recursive = TRUE)
+
+    meta_content <- c("Sample Name\tFactor Value[time point]", "0-0001-1\tpreop")
+    meta_tmp <- withr::local_tempfile()
+    writeLines(meta_content, meta_tmp)
+    meta_hash <- digest::digest(meta_tmp, algo = "sha256", file = TRUE)
+
+    benign_src <- file.path(work_root, "benign_src")
+    dir.create(file.path(benign_src, "Obs0_0001s", "3"), recursive = TRUE)
+    writeLines("spectrum-data", file.path(benign_src, "Obs0_0001s", "3", "1r"))
+    benign_zip <- file.path(work_root, "benign.zip")
+    withr::with_dir(benign_src, {
+        zip::zip(zipfile = benign_zip, files = file.path("Obs0_0001s", "3", "1r"))
+    })
+    zip_hash <- digest::digest(benign_zip, algo = "sha256", file = TRUE)
+
+    mock_curl_download_retry <- function(url, destfile, ...) {
+        if (grepl("metadata_sha256\\.json$", url)) {
+            jsonlite::write_json(list("s_MTBLS242.txt" = meta_hash), destfile, auto_unbox = TRUE)
+        } else if (grepl("data_sha256\\.json$", url)) {
+            jsonlite::write_json(list("FILES/Obs0_0001s.zip" = zip_hash), destfile, auto_unbox = TRUE)
+        } else if (grepl("s_MTBLS242\\.txt$", url, ignore.case = TRUE)) {
+            writeLines(meta_content, destfile)
+        } else if (grepl("\\.zip$", url)) {
+            file.copy(benign_zip, destfile, overwrite = TRUE)
+        } else {
+            stop("Unexpected curl_download_retry() call in test mock: ", url)
+        }
+        invisible(destfile)
+    }
+    testthat::local_mocked_bindings(
+        curl_download_retry = mock_curl_download_retry,
+        .package = "AlpsNMR"
+    )
+
+    expect_no_error(
+        download_MTBLS242(
+            dest_dir = dest_dir,
+            force = TRUE,
+            keep_only_CPMG_1r = TRUE,
+            keep_only_preop_and_3months = TRUE,
+            keep_only_complete_time_points = TRUE
+        )
+    )
+    expect_true(file.exists(file.path(dst_rootdir, "Obs0_0001s.zip")))
+})
+
+test_that("download_MTBLS242() aborts a fresh download that doesn't match MetaboLights' canonical SHA-256", {
+    skip_if_not_installed("zip")
+    skip_if_not_installed("fs")
+    skip_if_not_installed("digest")
+    skip_if_not_installed("jsonlite")
+
+    work_root <- withr::local_tempdir()
+    dest_dir <- file.path(work_root, "mtbls_test")
+    dst_rootdir <- file.path(dest_dir, "samples")
+    dir.create(dst_rootdir, recursive = TRUE)
+
+    wrong_hash <- strrep("0", 64) # deliberately does not match the served content
+
+    mock_curl_download_retry <- function(url, destfile, ...) {
+        if (grepl("metadata_sha256\\.json$", url)) {
+            jsonlite::write_json(list("s_MTBLS242.txt" = wrong_hash), destfile, auto_unbox = TRUE)
+        } else if (grepl("data_sha256\\.json$", url)) {
+            jsonlite::write_json(list(), destfile)
+        } else if (grepl("s_MTBLS242\\.txt$", url, ignore.case = TRUE)) {
+            writeLines(
+                c("Sample Name\tFactor Value[time point]", "0-0001-1\tpreop"),
+                destfile
+            )
+        } else {
+            stop("Unexpected curl_download_retry() call in test mock: ", url)
+        }
+        invisible(destfile)
+    }
+    testthat::local_mocked_bindings(
+        curl_download_retry = mock_curl_download_retry,
+        .package = "AlpsNMR"
+    )
+
+    expect_error(
+        download_MTBLS242(
+            dest_dir = dest_dir,
+            force = TRUE,
+            keep_only_CPMG_1r = TRUE,
+            keep_only_preop_and_3months = TRUE,
+            keep_only_complete_time_points = TRUE
+        ),
+        regexp = "published\\s+by MetaboLights"
+    )
+})
+
+test_that("download_MTBLS242() falls back to pinning local SHA-256 checksums when the canonical manifest is unavailable", {
     skip_if_not_installed("zip")
     skip_if_not_installed("fs")
     skip_if_not_installed("digest")
 
-    # download_MTBLS242() fetches this dataset over plain, unauthenticated FTP,
-    # and MetaboLights does not publish a canonical checksum for these files
-    # that the package could verify a fresh download against (see the NOTE
-    # (security) comment in download_MTBLS242()). What the function *can* do
-    # is pin the SHA-256 of every downloaded file to `<dest_dir>/SHA256SUMS`
-    # the first time it is saved, and re-verify it on every later call that
-    # reuses the cached file, so local corruption/tampering between calls is
-    # detected instead of being silently accepted.
+    # If MetaboLights' canonical SHA-256 manifest cannot be fetched (network
+    # issue, simulated here by simply not mocking the HASHES/*.json
+    # requests), download_MTBLS242() falls back to a local-only safety net:
+    # the SHA-256 of every downloaded file is pinned to
+    # `<dest_dir>/SHA256SUMS` the first time it is saved, and re-verified on
+    # every later call that reuses the cached file, so local
+    # corruption/tampering between calls is still detected.
     work_root <- withr::local_tempdir()
     dest_dir <- file.path(work_root, "mtbls_test")
     dst_rootdir <- file.path(dest_dir, "samples")
@@ -169,7 +281,7 @@ test_that("download_MTBLS242() pins SHA-256 checksums and detects local tamperin
     })
 
     mock_curl_download_retry <- function(url, destfile, ...) {
-        if (grepl("s_mtbls242\\.txt$", url)) {
+        if (grepl("s_MTBLS242\\.txt$", url, ignore.case = TRUE)) {
             writeLines(
                 c("Sample Name\tFactor Value[time point]", "0-0001-1\tpreop"),
                 destfile
@@ -186,7 +298,8 @@ test_that("download_MTBLS242() pins SHA-256 checksums and detects local tamperin
         .package = "AlpsNMR"
     )
 
-    # First download: checksums get pinned to SHA256SUMS.
+    # First download: the canonical manifest fetch fails (not mocked) and
+    # checksums get pinned locally to SHA256SUMS instead.
     download_MTBLS242(
         dest_dir = dest_dir,
         force = TRUE,

--- a/tests/testthat/test-download_MTBLS242.R
+++ b/tests/testthat/test-download_MTBLS242.R
@@ -141,3 +141,89 @@ test_that("download_MTBLS242() extracts a benign zip archive normally", {
     )
     expect_true(file.exists(file.path(dst_rootdir, "Obs0_0001s.zip")))
 })
+
+test_that("download_MTBLS242() pins SHA-256 checksums and detects local tampering with cached files", {
+    skip_if_not_installed("zip")
+    skip_if_not_installed("fs")
+    skip_if_not_installed("digest")
+
+    # download_MTBLS242() fetches this dataset over plain, unauthenticated FTP,
+    # and MetaboLights does not publish a canonical checksum for these files
+    # that the package could verify a fresh download against (see the NOTE
+    # (security) comment in download_MTBLS242()). What the function *can* do
+    # is pin the SHA-256 of every downloaded file to `<dest_dir>/SHA256SUMS`
+    # the first time it is saved, and re-verify it on every later call that
+    # reuses the cached file, so local corruption/tampering between calls is
+    # detected instead of being silently accepted.
+    work_root <- withr::local_tempdir()
+    dest_dir <- file.path(work_root, "mtbls_test")
+    dst_rootdir <- file.path(dest_dir, "samples")
+    dir.create(dst_rootdir, recursive = TRUE)
+
+    benign_src <- file.path(work_root, "benign_src")
+    dir.create(file.path(benign_src, "Obs0_0001s", "3"), recursive = TRUE)
+    writeLines("spectrum-data", file.path(benign_src, "Obs0_0001s", "3", "1r"))
+    benign_zip <- file.path(work_root, "benign.zip")
+    withr::with_dir(benign_src, {
+        zip::zip(zipfile = benign_zip, files = file.path("Obs0_0001s", "3", "1r"))
+    })
+
+    mock_curl_download_retry <- function(url, destfile, ...) {
+        if (grepl("s_mtbls242\\.txt$", url)) {
+            writeLines(
+                c("Sample Name\tFactor Value[time point]", "0-0001-1\tpreop"),
+                destfile
+            )
+        } else if (grepl("\\.zip$", url)) {
+            file.copy(benign_zip, destfile, overwrite = TRUE)
+        } else {
+            stop("Unexpected curl_download_retry() call in test mock: ", url)
+        }
+        invisible(destfile)
+    }
+    testthat::local_mocked_bindings(
+        curl_download_retry = mock_curl_download_retry,
+        .package = "AlpsNMR"
+    )
+
+    # First download: checksums get pinned to SHA256SUMS.
+    download_MTBLS242(
+        dest_dir = dest_dir,
+        force = TRUE,
+        keep_only_CPMG_1r = TRUE,
+        keep_only_preop_and_3months = TRUE,
+        keep_only_complete_time_points = TRUE
+    )
+    manifest_file <- file.path(dest_dir, "SHA256SUMS")
+    expect_true(file.exists(manifest_file))
+    sample_zip <- file.path(dst_rootdir, "Obs0_0001s.zip")
+    expected_hash <- digest::digest(sample_zip, algo = "sha256", file = TRUE)
+    manifest <- readLines(manifest_file)
+    expect_true(any(grepl(paste0("^", expected_hash, "  samples/Obs0_0001s\\.zip$"), manifest)))
+
+    # A subsequent call that reuses the cached file (force = FALSE) must
+    # verify it against the pinned checksum without error or re-download.
+    expect_no_error(
+        download_MTBLS242(
+            dest_dir = dest_dir,
+            force = FALSE,
+            keep_only_CPMG_1r = TRUE,
+            keep_only_preop_and_3months = TRUE,
+            keep_only_complete_time_points = TRUE
+        )
+    )
+
+    # Tampering with (or corrupting) the cached sample zip after it was
+    # pinned must be caught and refused, not silently used.
+    writeBin(as.raw(c(0, 1, 2, 3)), sample_zip)
+    expect_error(
+        download_MTBLS242(
+            dest_dir = dest_dir,
+            force = FALSE,
+            keep_only_CPMG_1r = TRUE,
+            keep_only_preop_and_3months = TRUE,
+            keep_only_complete_time_points = TRUE
+        ),
+        regexp = "Checksum mismatch"
+    )
+})


### PR DESCRIPTION
## Summary

- `download_MTBLS242()` still downloads data over FTP, as required by [MetaboLights' documentation](https://ebi-metabolights.github.io/guides/Files/) ("If you want to download data files, you MUST use FTP, Aspera or Globus clients"), but now verifies every freshly downloaded file against the canonical SHA-256 checksums MetaboLights publishes for MTBLS242 at `<https_url>/HASHES/{metadata,data}_sha256.json` (fetched over HTTPS — the only part of this fix that uses HTTPS, since that path isn't documented as a supported way to download the data files themselves). A mismatch now aborts with a clear error instead of silently accepting a corrupted or tampered file.
- As a fallback for when that manifest can't be fetched, the SHA-256 of every downloaded file is also pinned to `<dest_dir>/SHA256SUMS` the first time it's saved and re-verified on every later call that reuses a cached file (including cache hits with `force = FALSE`).
- Also fixes two latent path bugs uncovered while wiring this up, both confirmed against the real FTP server: sample archives live under a `FILES/` subdirectory that the old code didn't include, and the metadata file is `s_MTBLS242.txt` (uppercase), not `s_mtbls242.txt` as previously requested.
- Adds `digest` and `jsonlite` as new `Suggests` dependencies (following the existing pattern for `curl`/`zip`, gated by `require_pkgs()`).

Fixes #72.

## Test plan

- [x] `testthat` suite for `download_MTBLS242()` extended with new cases: canonical-checksum verification on a fresh download, abort on canonical mismatch, and the local-pin fallback (pin-on-first-download, silent pass on a verified cache hit, abort on local tampering). All existing zip-slip tests still pass.
- [x] Live-verified (not just mocked) against the real MetaboLights server: fetched the real `HASHES/*.json` manifest (471 hashes), downloaded the real metadata file and a real sample zip over HTTPS, both verified successfully.
- [x] Confirmed via `curl` directly against the real FTP server (not just the HTTPS mirror): `FILES/Obs0_0001s.zip` and `s_MTBLS242.txt` both resolve (226 on `--list-only`), and the downloaded sample's SHA-256 matches the canonical manifest.
- [x] `roxygen2::roxygenise()` regenerated `man/download_MTBLS242.Rd` cleanly (no unrelated diffs).
