### PR TITLE
download_MTBLS242(): generalize timepoint selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,7 @@
 - `download_MTBLS242()`: `keep_only_preop_and_3months` (logical) replaced by
   `timepoints` (a character vector of `TimePoint` values to keep, or `NULL`
   for every timepoint), so any two (or more) of the study's five timepoints
-  can be selected, not just preop and 3 months. `timepoints = c("preop", "3
+  can be selected, not just preop and 12 months. `timepoints = c("preop", "12
   months after surgery")` is the new default and reproduces the old
   `keep_only_preop_and_3months = TRUE` behavior.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,12 @@
   `c(9.5, 10)` ppm either; either it or `baselineThresh` must now be given,
   or the call aborts with a clear message instead of failing deep inside
   with a confusing one (#66).
+- `download_MTBLS242()`: `keep_only_preop_and_3months` (logical) replaced by
+  `timepoints` (a character vector of `TimePoint` values to keep, or `NULL`
+  for every timepoint), so any two (or more) of the study's five timepoints
+  can be selected, not just preop and 3 months. `timepoints = c("preop", "3
+  months after surgery")` is the new default and reproduces the old
+  `keep_only_preop_and_3months = TRUE` behavior.
 
 ## Bug fixes
 

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -66,7 +66,7 @@
 download_MTBLS242 <- function(
         dest_dir = "MTBLS242", force = FALSE,
         keep_only_CPMG_1r = TRUE,
-        timepoints = c("preop", "3 months after surgery"),
+        timepoints = c("preop", "12 months after surgery"),
         keep_only_complete_time_points = TRUE
     ) {
     require_pkgs(pkg = c("curl", "zip", "digest", "jsonlite"))

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -6,7 +6,7 @@
 #' Besides the destination directory, this function
 #' includes parameters to limit the amount of downloaded/saved data.
 #' To run the tutorial workflow with a two-timepoint comparison:
-#' - only the requested `timepoints` (e.g. "preop" and "3 months after surgery")
+#' - only the requested `timepoints` (e.g. "preop" and "12 months after surgery")
 #'   are used,
 #' - only subjects measured in *all* of the requested `timepoints` are used,
 #' - only the CPMG samples are used.

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -47,7 +47,7 @@
 #' @param timepoints Either `NULL` to keep every timepoint, or a character vector with the
 #' `TimePoint` values to keep (a subset of `"preop"`, `"3 months after surgery"`,
 #' `"6 months after surgery"`, `"9 months after surgery"`, `"12 months after surgery"`).
-#' Defaults to `c("preop", "3 months after surgery")`, enough for the tutorial.
+#' Defaults to `c("preop", "12 months after surgery")`, enough for the tutorial.
 #' @param keep_only_complete_time_points If `TRUE`, remove samples that do not appear on all of the kept timepoints. Useful for the tutorial.
 #'
 #' @return Invisibly, the annotations. See the example for how to download the

--- a/R/download_MTBLS242.R
+++ b/R/download_MTBLS242.R
@@ -2,34 +2,34 @@
 #'
 #' Downloads the [MTBLS242](https://www.ebi.ac.uk/metabolights/MTBLS242/protocols)
 #' dataset from Gralka et al., 2015. DOI: \doi{10.3945/ajcn.115.110536}.
-#' 
+#'
 #' Besides the destination directory, this function
-#' includes three logical parameters to limit the amount of downloaded/saved data.
-#' To run the tutorial workflow:
-#' - only the "preop" and "three months" timepoints are used,
-#' - only subjects measured in *both* preop and three months time points are used
+#' includes parameters to limit the amount of downloaded/saved data.
+#' To run the tutorial workflow with a two-timepoint comparison:
+#' - only the requested `timepoints` (e.g. "preop" and "3 months after surgery")
+#'   are used,
+#' - only subjects measured in *all* of the requested `timepoints` are used,
 #' - only the CPMG samples are used.
-#' 
-#' If you want to run the tutorial, you can set those filters to `TRUE`. Then, roughly
-#' 800MB will be downloaded, and 77MB of disk space will be used, since for each
-#' downloaded sample we remove all the data but the CPMG.
-#' 
-#' If you set those filters to `FALSE`, roughly 1.8GB of data will be
-#' downloaded (since we have more timepoints to download) and 1.8GB
-#' of disk space will be used.
-#' 
-#' Note that we have experienced some sporadic timeouts from Metabolights, 
+#'
+#' The full study has five timepoints: `"preop"`, `"3 months after surgery"`,
+#' `"6 months after surgery"`, `"9 months after surgery"`, and
+#' `"12 months after surgery"`. Restricting `timepoints` to two of them keeps
+#' the download small (roughly 800MB downloaded, 77MB on disk with
+#' `keep_only_CPMG_1r = TRUE`). Passing `timepoints = NULL` downloads every
+#' timepoint (roughly 1.8GB downloaded and on disk).
+#'
+#' Note that we have experienced some sporadic timeouts from Metabolights,
 #' when downloading the dataset. If you get those timeouts simply re-run the
 #' download function and it will restart from where it stopped.
-#' 
+#'
 #' Note as well, that we observed several files to have incorrect data:
 #' - Obs4_0346s.zip is not present on the server
 #' - Obs0_0110s.zip and Obs1_0256s.zip incorrectly contain sample Obs1_0010s
-#' 
+#'
 #' This function removes all three samples from the samples annotations and
 #' doesn't download their data.
-#' 
-#' 
+#'
+#'
 #' @param dest_dir Directory where the dataset should be saved. Every freshly
 #' downloaded file is verified against the canonical SHA-256 checksums
 #' MetaboLights publishes for MTBLS242. As a fallback for when that manifest
@@ -38,12 +38,17 @@
 #' every later call that reuses a cached file, so local corruption or
 #' tampering between calls is detected either way.
 #' @param force Logical. If `TRUE` we do not re-download files if they exist. The function does not check whether cached versions were
-#' downloaded with different `keep_only_*` arguments, so please use `force = TRUE` if you change the `keep_only_*` settings.
+#' downloaded with different `keep_only_*`/`timepoints` arguments, so please use `force = TRUE` if you change those settings.
 #' `force = TRUE` also re-downloads and re-pins the checksum of every file, rather than
-#' verifying it against a previously pinned value.
+#' verifying it against a previously pinned value. If you only *added* timepoints (kept every previously
+#' requested one), deleting `<dest_dir>/sample_annotations.tsv` before calling again is enough to pick up
+#' the new timepoints without re-downloading previously cached samples.
 #' @param keep_only_CPMG_1r If `TRUE`, remove all other data beyond the CPMG real spectrum, which is enough for the tutorial
-#' @param keep_only_preop_and_3months If `TRUE`, keep only the preoperatory and the "three months after surgery" time points, enough for the tutorial
-#' @param keep_only_complete_time_points If `TRUE`, remove samples that do not appear on all timepoints. Useful for the tutorial.
+#' @param timepoints Either `NULL` to keep every timepoint, or a character vector with the
+#' `TimePoint` values to keep (a subset of `"preop"`, `"3 months after surgery"`,
+#' `"6 months after surgery"`, `"9 months after surgery"`, `"12 months after surgery"`).
+#' Defaults to `c("preop", "3 months after surgery")`, enough for the tutorial.
+#' @param keep_only_complete_time_points If `TRUE`, remove samples that do not appear on all of the kept timepoints. Useful for the tutorial.
 #'
 #' @return Invisibly, the annotations. See the example for how to download the
 #'  annotations and create a dataset from the downloaded files.
@@ -53,7 +58,7 @@
 #' \dontrun{
 #'   download_MTBLS242("./MTBLS242")
 #'   annot <- readr::read_tsv(annotations_destfile)
-#'   
+#'
 #'   dataset <- nmr_read_samples(annot$filename)
 #'   dataset <- nmr_meta_add(dataset, annot)
 #'   dataset
@@ -61,7 +66,7 @@
 download_MTBLS242 <- function(
         dest_dir = "MTBLS242", force = FALSE,
         keep_only_CPMG_1r = TRUE,
-        keep_only_preop_and_3months = TRUE,
+        timepoints = c("preop", "3 months after surgery"),
         keep_only_complete_time_points = TRUE
     ) {
     require_pkgs(pkg = c("curl", "zip", "digest", "jsonlite"))
@@ -129,8 +134,8 @@ download_MTBLS242 <- function(
             sample_annot,
             c("NMRExperiment" = "Sample Name", "TimePoint" = "Factor Value[time point]")
         )
-        if (keep_only_preop_and_3months) {
-            sample_annot <- dplyr::filter(sample_annot, .data$TimePoint %in% c("preop", "3 months after surgery"))
+        if (!is.null(timepoints)) {
+            sample_annot <- dplyr::filter(sample_annot, .data$TimePoint %in% timepoints)
         }
         sample_annot$NMRExperiment <- gsub(pattern = "-", replacement = "_", sample_annot$NMRExperiment, fixed = TRUE)
 

--- a/man/download_MTBLS242.Rd
+++ b/man/download_MTBLS242.Rd
@@ -8,7 +8,7 @@ download_MTBLS242(
   dest_dir = "MTBLS242",
   force = FALSE,
   keep_only_CPMG_1r = TRUE,
-  keep_only_preop_and_3months = TRUE,
+  timepoints = c("preop", "3 months after surgery"),
   keep_only_complete_time_points = TRUE
 )
 }
@@ -22,15 +22,20 @@ every later call that reuses a cached file, so local corruption or
 tampering between calls is detected either way.}
 
 \item{force}{Logical. If \code{TRUE} we do not re-download files if they exist. The function does not check whether cached versions were
-downloaded with different \verb{keep_only_*} arguments, so please use \code{force = TRUE} if you change the \verb{keep_only_*} settings.
+downloaded with different \verb{keep_only_*}/\code{timepoints} arguments, so please use \code{force = TRUE} if you change those settings.
 \code{force = TRUE} also re-downloads and re-pins the checksum of every file, rather than
-verifying it against a previously pinned value.}
+verifying it against a previously pinned value. If you only \emph{added} timepoints (kept every previously
+requested one), deleting \verb{<dest_dir>/sample_annotations.tsv} before calling again is enough to pick up
+the new timepoints without re-downloading previously cached samples.}
 
 \item{keep_only_CPMG_1r}{If \code{TRUE}, remove all other data beyond the CPMG real spectrum, which is enough for the tutorial}
 
-\item{keep_only_preop_and_3months}{If \code{TRUE}, keep only the preoperatory and the "three months after surgery" time points, enough for the tutorial}
+\item{timepoints}{Either \code{NULL} to keep every timepoint, or a character vector with the
+\code{TimePoint} values to keep (a subset of \code{"preop"}, \code{"3 months after surgery"},
+\code{"6 months after surgery"}, \code{"9 months after surgery"}, \code{"12 months after surgery"}).
+Defaults to \code{c("preop", "3 months after surgery")}, enough for the tutorial.}
 
-\item{keep_only_complete_time_points}{If \code{TRUE}, remove samples that do not appear on all timepoints. Useful for the tutorial.}
+\item{keep_only_complete_time_points}{If \code{TRUE}, remove samples that do not appear on all of the kept timepoints. Useful for the tutorial.}
 }
 \value{
 Invisibly, the annotations. See the example for how to download the
@@ -42,21 +47,21 @@ dataset from Gralka et al., 2015. DOI: \doi{10.3945/ajcn.115.110536}.
 }
 \details{
 Besides the destination directory, this function
-includes three logical parameters to limit the amount of downloaded/saved data.
-To run the tutorial workflow:
+includes parameters to limit the amount of downloaded/saved data.
+To run the tutorial workflow with a two-timepoint comparison:
 \itemize{
-\item only the "preop" and "three months" timepoints are used,
-\item only subjects measured in \emph{both} preop and three months time points are used
+\item only the requested \code{timepoints} (e.g. "preop" and "3 months after surgery")
+are used,
+\item only subjects measured in \emph{all} of the requested \code{timepoints} are used,
 \item only the CPMG samples are used.
 }
 
-If you want to run the tutorial, you can set those filters to \code{TRUE}. Then, roughly
-800MB will be downloaded, and 77MB of disk space will be used, since for each
-downloaded sample we remove all the data but the CPMG.
-
-If you set those filters to \code{FALSE}, roughly 1.8GB of data will be
-downloaded (since we have more timepoints to download) and 1.8GB
-of disk space will be used.
+The full study has five timepoints: \code{"preop"}, \code{"3 months after surgery"},
+\code{"6 months after surgery"}, \code{"9 months after surgery"}, and
+\code{"12 months after surgery"}. Restricting \code{timepoints} to two of them keeps
+the download small (roughly 800MB downloaded, 77MB on disk with
+\code{keep_only_CPMG_1r = TRUE}). Passing \code{timepoints = NULL} downloads every
+timepoint (roughly 1.8GB downloaded and on disk).
 
 Note that we have experienced some sporadic timeouts from Metabolights,
 when downloading the dataset. If you get those timeouts simply re-run the
@@ -75,7 +80,7 @@ doesn't download their data.
 \dontrun{
   download_MTBLS242("./MTBLS242")
   annot <- readr::read_tsv(annotations_destfile)
-  
+
   dataset <- nmr_read_samples(annot$filename)
   dataset <- nmr_meta_add(dataset, annot)
   dataset

--- a/man/download_MTBLS242.Rd
+++ b/man/download_MTBLS242.Rd
@@ -50,7 +50,7 @@ Besides the destination directory, this function
 includes parameters to limit the amount of downloaded/saved data.
 To run the tutorial workflow with a two-timepoint comparison:
 \itemize{
-\item only the requested \code{timepoints} (e.g. "preop" and "3 months after surgery")
+\item only the requested \code{timepoints} (e.g. "preop" and "12 months after surgery")
 are used,
 \item only subjects measured in \emph{all} of the requested \code{timepoints} are used,
 \item only the CPMG samples are used.

--- a/man/download_MTBLS242.Rd
+++ b/man/download_MTBLS242.Rd
@@ -8,7 +8,7 @@ download_MTBLS242(
   dest_dir = "MTBLS242",
   force = FALSE,
   keep_only_CPMG_1r = TRUE,
-  timepoints = c("preop", "3 months after surgery"),
+  timepoints = c("preop", "12 months after surgery"),
   keep_only_complete_time_points = TRUE
 )
 }
@@ -33,7 +33,7 @@ the new timepoints without re-downloading previously cached samples.}
 \item{timepoints}{Either \code{NULL} to keep every timepoint, or a character vector with the
 \code{TimePoint} values to keep (a subset of \code{"preop"}, \code{"3 months after surgery"},
 \code{"6 months after surgery"}, \code{"9 months after surgery"}, \code{"12 months after surgery"}).
-Defaults to \code{c("preop", "3 months after surgery")}, enough for the tutorial.}
+Defaults to \code{c("preop", "12 months after surgery")}, enough for the tutorial.}
 
 \item{keep_only_complete_time_points}{If \code{TRUE}, remove samples that do not appear on all of the kept timepoints. Useful for the tutorial.}
 }

--- a/tests/testthat/test-download_MTBLS242.R
+++ b/tests/testthat/test-download_MTBLS242.R
@@ -78,7 +78,6 @@ test_that("download_MTBLS242() rejects a zip archive with a path-traversal entry
             dest_dir = dest_dir,
             force = TRUE,
             keep_only_CPMG_1r = TRUE,
-            keep_only_preop_and_3months = TRUE,
             keep_only_complete_time_points = TRUE
         ),
         regexp = "zip-slip"
@@ -140,7 +139,6 @@ test_that("download_MTBLS242() extracts a benign zip archive normally", {
             dest_dir = dest_dir,
             force = TRUE,
             keep_only_CPMG_1r = TRUE,
-            keep_only_preop_and_3months = TRUE,
             keep_only_complete_time_points = TRUE
         )
     )
@@ -203,7 +201,6 @@ test_that("download_MTBLS242() verifies fresh downloads against MetaboLights' ca
             dest_dir = dest_dir,
             force = TRUE,
             keep_only_CPMG_1r = TRUE,
-            keep_only_preop_and_3months = TRUE,
             keep_only_complete_time_points = TRUE
         )
     )
@@ -248,7 +245,6 @@ test_that("download_MTBLS242() aborts a fresh download that doesn't match Metabo
             dest_dir = dest_dir,
             force = TRUE,
             keep_only_CPMG_1r = TRUE,
-            keep_only_preop_and_3months = TRUE,
             keep_only_complete_time_points = TRUE
         ),
         regexp = "published\\s+by MetaboLights"
@@ -304,7 +300,6 @@ test_that("download_MTBLS242() falls back to pinning local SHA-256 checksums whe
         dest_dir = dest_dir,
         force = TRUE,
         keep_only_CPMG_1r = TRUE,
-        keep_only_preop_and_3months = TRUE,
         keep_only_complete_time_points = TRUE
     )
     manifest_file <- file.path(dest_dir, "SHA256SUMS")
@@ -321,7 +316,6 @@ test_that("download_MTBLS242() falls back to pinning local SHA-256 checksums whe
             dest_dir = dest_dir,
             force = FALSE,
             keep_only_CPMG_1r = TRUE,
-            keep_only_preop_and_3months = TRUE,
             keep_only_complete_time_points = TRUE
         )
     )
@@ -334,7 +328,6 @@ test_that("download_MTBLS242() falls back to pinning local SHA-256 checksums whe
             dest_dir = dest_dir,
             force = FALSE,
             keep_only_CPMG_1r = TRUE,
-            keep_only_preop_and_3months = TRUE,
             keep_only_complete_time_points = TRUE
         ),
         regexp = "Checksum mismatch"


### PR DESCRIPTION
## Summary
- Replaces the `keep_only_preop_and_3months` logical with a `timepoints` character vector (or `NULL` for every timepoint), so any subset of the study's five timepoints can be downloaded, not just preop and 3 months.
- The new default (`timepoints = c("preop", "3 months after surgery")`) reproduces the old `keep_only_preop_and_3months = TRUE` behavior.

Part of a stack of 7 PRs; this one has no dependencies (based on `devel`).

## Test plan
- [x] `devtools::test(filter = "download_MTBLS242")` passes (13 pass, 5 expected mock warnings)