### PR TITLE
peaklist_fit_lorentzians(): gate the progress bar like every other one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,10 @@
 
 ## Bug fixes
 
+- `peaklist_fit_lorentzians()` (used by `nmr_detect_peaks(fit_lorentzians =
+  TRUE)`): its "Fitting lorentzians" progress bar was not gated behind the
+  same interactive/non-knitr check every other progress bar in the package
+  uses, so it always printed, including inside notebooks/vignettes.
 - `bp_kfold_VIP_analysis()`: fixed fold partitioning, which assigned samples
   to folds with a deterministic `x %% k` split instead of the intended random
   shuffle.

--- a/R/area_estimation.R
+++ b/R/area_estimation.R
@@ -172,7 +172,7 @@ peaklist_fit_lorentzians <- function(peak_data,
     x <- nmr_dataset$axis
     sindex_prev <- -1
     all_errors <- list(peak_id = character(0L), error_msg = character(0L))
-    pb <- progress_bar_new(name = "Fitting lorentzians", total = nrow(peak_data))
+    pb <- if (show_progress_bar(TRUE)) progress_bar_new(name = "Fitting lorentzians", total = nrow(peak_data)) else NULL
 
     nmr_exp_to_sample_idx <- purrr::set_names(
         seq_len(nmr_dataset$num_samples),


### PR DESCRIPTION
## Summary
- Its "Fitting lorentzians" progress bar was not gated behind the interactive/non-knitr check every other progress bar in the package uses, so it always printed, including inside notebooks/vignettes.

Part of a stack of 7 PRs; **based on #111** (merge the stack in order). GitHub will retarget this to `devel` automatically once earlier PRs merge.

## Test plan
- [x] `devtools::test(filter = "peak.fitting|area_estimation|lorentzian")` passes (34 pass)