### PR TITLE
nmr_identify_regions_*(): drop NA-padded unmatched rows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,11 @@
   TRUE)`): its "Fitting lorentzians" progress bar was not gated behind the
   same interactive/non-knitr check every other progress bar in the package
   uses, so it always printed, including inside notebooks/vignettes.
+- `nmr_identify_regions_blood()` / `nmr_identify_regions_urine()` /
+  `nmr_identify_regions_cell()`: each `ppm_to_assign` query always
+  contributed exactly `num_proposed_compounds` rows, padding with `NA` when
+  fewer candidate metabolites were found within tolerance; those `NA`-only
+  rows are now dropped instead of returned.
 - `bp_kfold_VIP_analysis()`: fixed fold partitioning, which assigned samples
   to folds with a deterministic `x %% k` split instead of the intended random
   shuffle.

--- a/R/nmr_identify_regions.R
+++ b/R/nmr_identify_regions.R
@@ -44,6 +44,7 @@ nmr_identify_regions_blood <- function(ppm_to_assign, num_proposed_compounds = 3
     # colnames(counts) <- c("Metabolite", "Counts")
     # output_assignation_list <- merge(output_assignation_list,counts, by = "Metabolite")
     output_assignation_list <- output_assignation_list[order(output_assignation_list$ppm_to_assign, -output_assignation_list$Blood_concentration, -output_assignation_list$n_reported_in_Blood), ]
+    output_assignation_list <- output_assignation_list[!is.na(output_assignation_list$Metabolite), , drop = FALSE]
     return(output_assignation_list)
 }
 
@@ -106,6 +107,7 @@ nmr_identify_regions_urine <- function(ppm_to_assign, num_proposed_compounds = 5
     # colnames(counts) <- c("Metabolite", "Counts")
     # output_assignation_list <- merge(output_assignation_list,counts, by = "Metabolite")
     output_assignation_list <- output_assignation_list[order(output_assignation_list$ppm_to_assign, -output_assignation_list$Urine_concentration, -output_assignation_list$n_reported_in_Urine), ]
+    output_assignation_list <- output_assignation_list[!is.na(output_assignation_list$Metabolite), , drop = FALSE]
     return(output_assignation_list)
 }
 
@@ -162,6 +164,7 @@ nmr_identify_regions_cell <- function(ppm_to_assign, num_proposed_compounds = 3,
     }
     output_assignation_list$ppm_to_assign <- rep(ppm_to_assign, each = num_proposed_compounds)
     output_assignation_list <- output_assignation_list[order(output_assignation_list$ppm_to_assign), ]
+    output_assignation_list <- output_assignation_list[!is.na(output_assignation_list$Metabolite), , drop = FALSE]
     return(output_assignation_list)
 }
 


### PR DESCRIPTION
## Summary
- Each `ppm_to_assign` query always contributed exactly `num_proposed_compounds` rows, padding with `NA` when fewer candidate metabolites were found within tolerance. Those `NA`-only rows carry no information and are confusing to read, so they are dropped instead of returned.
- Applies to `nmr_identify_regions_blood()`, `nmr_identify_regions_urine()`, and `nmr_identify_regions_cell()`.

Part of a stack of 7 PRs; **based on #112** (merge the stack in order). GitHub will retarget this to `devel` automatically once earlier PRs merge.

## Test plan
- [x] `devtools::test(filter = "identify_regions")` passes (3 pass)