### PR TITLE
models_stability_plot_*(): fixed, sign-agnostic loadings color scale

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,17 @@
   contributed exactly `num_proposed_compounds` rows, padding with `NA` when
   fewer candidate metabolites were found within tolerance; those `NA`-only
   rows are now dropped instead of returned.
+- `models_stability_plot_plsda()` / `models_stability_plot_bootstrap()`: the
+  loadings-correlation heatmap now uses a fixed, sign-agnostic color scale
+  (-1 and +1 both render as the same dark blue, 0 as white; a latent
+  variable's sign is arbitrary, so -1 and +1 indicate equally strong
+  agreement) instead of a plain sequential palette that auto-scaled to
+  whatever range the data happened to have. Also fixes self-correlation
+  cells (expected to be exactly 1) intermittently rendering as blank/white:
+  a loading vector's self dot-product can come out as e.g.
+  `1.0000000000000002` due to floating-point rounding, which fell just
+  outside the (`-1`, `1`) scale limits and was dropped to `NA` by ggplot2's
+  default out-of-bounds handling; now clamped to the nearest limit instead.
 - `bp_kfold_VIP_analysis()`: fixed fold partitioning, which assigned samples
   to folds with a deterministic `x %% k` split instead of the intended random
   shuffle.

--- a/R/nmr_data_analysis_model_stability.R
+++ b/R/nmr_data_analysis_model_stability.R
@@ -101,9 +101,18 @@ models_stability_plot_plsda <- function(model) {
         ggplot2::geom_tile() +
         ggplot2::coord_equal() +
         ggplot2::theme_bw() +
-        ggplot2::scale_fill_distiller(
-            palette = "Blues",
-            direction = 1,
+        ggplot2::scale_fill_gradient2(
+            low = "#08519C",
+            mid = "white",
+            high = "#08519C",
+            midpoint = 0,
+            limits = c(-1, 1),
+            # A self dot-product of a (near-)unit loading vector can come out
+            # as e.g. 1.0000000000000002 due to floating-point rounding,
+            # which falls just outside `limits`; squish (clamp to the
+            # nearest limit) instead of the default censor (drop to NA,
+            # rendered as na.value), or such cells silently turn white.
+            oob = scales::squish,
             na.value = "white"
         ) +
         ggplot2::guides(fill = "none") + # removing legend for `fill`
@@ -111,7 +120,12 @@ models_stability_plot_plsda <- function(model) {
         ggplot2::geom_text(
             ggplot2::aes(
                 label = round(.data[["value"]], digits = 2),
-                color = ifelse(.data[["value"]] > 0.5, 1, 0)
+                # A latent variable's sign is arbitrary, so a loading
+                # correlation of -1 is drawn in the same dark blue as +1
+                # (see scale_fill_gradient2() above); the label color must
+                # therefore switch on |value|, not value, to stay legible
+                # against strongly negative tiles too.
+                color = ifelse(abs(.data[["value"]]) > 0.5, 1, 0)
             ),
             size = 2.5,
             show.legend = FALSE
@@ -229,9 +243,18 @@ models_stability_plot_bootstrap <- function(bp_results) {
         ggplot2::geom_tile() +
         ggplot2::coord_equal() +
         ggplot2::theme_bw() +
-        ggplot2::scale_fill_distiller(
-            palette = "Blues",
-            direction = 1,
+        ggplot2::scale_fill_gradient2(
+            low = "#08519C",
+            mid = "white",
+            high = "#08519C",
+            midpoint = 0,
+            limits = c(-1, 1),
+            # A self dot-product of a (near-)unit loading vector can come out
+            # as e.g. 1.0000000000000002 due to floating-point rounding,
+            # which falls just outside `limits`; squish (clamp to the
+            # nearest limit) instead of the default censor (drop to NA,
+            # rendered as na.value), or such cells silently turn white.
+            oob = scales::squish,
             na.value = "white"
         ) +
         ggplot2::guides(fill = "none") + # removing legend for `fill`
@@ -239,7 +262,12 @@ models_stability_plot_bootstrap <- function(bp_results) {
         ggplot2::geom_text(
             ggplot2::aes(
                 label = round(.data[["value"]], digits = 2),
-                color = ifelse(.data[["value"]] > 0.5, 1, 0)
+                # A latent variable's sign is arbitrary, so a loading
+                # correlation of -1 is drawn in the same dark blue as +1
+                # (see scale_fill_gradient2() above); the label color must
+                # therefore switch on |value|, not value, to stay legible
+                # against strongly negative tiles too.
+                color = ifelse(abs(.data[["value"]]) > 0.5, 1, 0)
             ),
             size = 2.5,
             show.legend = FALSE


### PR DESCRIPTION
## Summary
- Use a fixed -1 (dark blue) / 0 (white) / +1 (dark blue) color scale instead of a plain sequential palette that auto-scaled to whatever range the data happened to have -- a latent variable's sign is arbitrary, so -1 and +1 both indicate equally strong agreement between folds and should render identically.
- Also fixes self-correlation cells (expected to be exactly 1) intermittently rendering as blank/white: a loading vector's self dot-product can come out as e.g. `1.0000000000000002` due to floating-point rounding, which fell just outside the (-1, 1) scale limits and was dropped to `NA` by ggplot2's default out-of-bounds handling; now clamped to the nearest limit instead.

Part of a stack of 7 PRs; **based on #113** (merge the stack in order). GitHub will retarget this to `devel` automatically once earlier PRs merge.

## Test plan
- [x] `devtools::test(filter = "model_stability|stability")` passes (16 pass)